### PR TITLE
[I-030] 统一接入网关（Ingest Gateway v2）

### DIFF
--- a/src/collector/README.md
+++ b/src/collector/README.md
@@ -16,20 +16,23 @@
 - `GET /api/v1/ops/failed-events`：查看失败事件审计与状态
 - `POST /api/v1/ops/failed-events/replay`：手动重放失败事件
 - `POST /api/v1/ingest/{kind}`：上报入口
+- `POST /api/v2/ingest/{kind}`：v2 上报入口（与 v1 并行）
   - kind 取值：`node_metric`、`node-metric`、`link_metric`、`link-metric`、`flow`、`alarm`
 - Header：
   - `x-api-token`：上报鉴权
 
 ## 必填字段
 - 所有事件必须包含：
-  - `schema_version=monitor.v1`
+  - `schema_version=monitor.v1|monitor.v2`
   - `message_id`
 - `timestamp` 缺省可由服务端补齐
 
 ## 错误码
 - `INVALID_PAYLOAD`：字段校验失败
 - `INVALID_KIND`：不支持事件类型
-- `UNAUTHORIZED`：鉴权失败
+- `AUTH_TOKEN_MISSING`：缺少 token
+- `AUTH_TOKEN_INVALID`：token 不匹配
+- `RATE_LIMITED`：同一 producer 触发限流
 - `NATS_UNAVAILABLE`：事件总线不可用
 
 ## 幂等策略
@@ -52,6 +55,7 @@
 - `TSDB_ENABLED`：是否启用 Timescale 写入（默认 `true`）
 - `TSDB_DSN`：Timescale 连接串
 - `TSDB_SCHEMA`：写入 schema（默认 `monitor_ts`）
+- `PRODUCER_RATE_LIMIT_RPM`：按 producer 每分钟限流阈值（`0` 表示关闭）
 
 ## Timescale 写入
 - 入站事件在发布 NATS 成功后会尝试写入 Timescale（四类表）

--- a/src/collector/app/config.py
+++ b/src/collector/app/config.py
@@ -23,6 +23,7 @@ class CollectorConfig:
     tsdb_enabled: bool
     tsdb_dsn: str
     tsdb_schema: str
+    producer_rate_limit_rpm: int
 
 
 def load_config(path: str = "/app/config.example.yaml") -> CollectorConfig:
@@ -56,4 +57,7 @@ def load_config(path: str = "/app/config.example.yaml") -> CollectorConfig:
             raw.get("tsdb_dsn", "postgresql://monitor:monitor123@monitor_timescaledb:5432/monitor"),
         ),
         tsdb_schema=os.environ.get("TSDB_SCHEMA", raw.get("tsdb_schema", "monitor_ts")),
+        producer_rate_limit_rpm=int(
+            os.environ.get("PRODUCER_RATE_LIMIT_RPM", raw.get("producer_rate_limit_rpm", 0))
+        ),
     )

--- a/src/collector/app/contract.py
+++ b/src/collector/app/contract.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-SCHEMA_VERSION = "monitor.v1"
+SCHEMA_VERSIONS = {"monitor.v1", "monitor.v2"}
 
 ALLOWED_NODE_STATUS = {"UP", "DOWN", "DEGRADED"}
 ALLOWED_LINK_STATE = {"UP", "DOWN", "DEGRADED"}
@@ -40,8 +40,8 @@ def _check_ratio(payload: dict[str, Any], key: str) -> None:
 def validate_common(payload: dict[str, Any]) -> None:
     _require(payload, "schema_version")
     _require(payload, "message_id")
-    if payload.get("schema_version") != SCHEMA_VERSION:
-        raise ContractError("INVALID_PAYLOAD", "schema_version 必须为 monitor.v1")
+    if payload.get("schema_version") not in SCHEMA_VERSIONS:
+        raise ContractError("INVALID_PAYLOAD", "schema_version 仅支持 monitor.v1|monitor.v2")
 
 
 def validate_payload(event_type: str, payload: dict[str, Any]) -> None:

--- a/src/collector/app/main.py
+++ b/src/collector/app/main.py
@@ -9,8 +9,9 @@ from .config import load_config
 from .failed_events import FailedEventStore
 from .observability import OutcomeStats
 from .publisher import EventPublisher
+from .rate_limit import ProducerRateLimiter
 from .repository import IdempotentStore
-from .routes import router
+from .routes import router, router_v2
 from .snapshot import MonitorSnapshotStore
 from .storage import TimescaleWriter
 
@@ -20,6 +21,7 @@ def create_app() -> FastAPI:
 
     app = FastAPI(title="net-analysis collector")
     app.include_router(router)
+    app.include_router(router_v2)
 
     app.state.config = config
     app.state.publisher = EventPublisher(
@@ -34,6 +36,7 @@ def create_app() -> FastAPI:
         max_items=config.failed_events_max_items,
         audit_file_path=config.failed_events_audit_file,
     )
+    app.state.rate_limiter = ProducerRateLimiter(rpm=config.producer_rate_limit_rpm)
     app.state.ts_writer = None
     if config.tsdb_enabled:
         app.state.ts_writer = TimescaleWriter(config.tsdb_dsn, schema=config.tsdb_schema)

--- a/src/collector/app/observability.py
+++ b/src/collector/app/observability.py
@@ -8,14 +8,23 @@ class OutcomeStats:
     def __init__(self) -> None:
         self._lock = Lock()
         self._counter: Counter[str] = Counter()
+        self._dup_by_event_type: Counter[str] = Counter()
+        self._dup_by_producer: Counter[str] = Counter()
 
-    def record(self, code: str) -> None:
+    def record(self, code: str, event_type: str | None = None, producer: str | None = None) -> None:
         with self._lock:
             self._counter[code] += 1
+            if code == "DUPLICATE":
+                if event_type:
+                    self._dup_by_event_type[event_type] += 1
+                if producer:
+                    self._dup_by_producer[producer] += 1
 
     def snapshot(self) -> dict[str, object]:
         with self._lock:
             counts = dict(self._counter)
+            dup_event = dict(self._dup_by_event_type)
+            dup_producer = dict(self._dup_by_producer)
 
         total = sum(counts.values())
         ok = counts.get("OK", 0)
@@ -32,4 +41,6 @@ class OutcomeStats:
             "success_rate": success_rate,
             "fail_rate": fail_rate,
             "by_code": counts,
+            "duplicate_by_event_type": dup_event,
+            "duplicate_by_producer": dup_producer,
         }

--- a/src/collector/app/rate_limit.py
+++ b/src/collector/app/rate_limit.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+from threading import Lock
+
+
+class ProducerRateLimiter:
+    def __init__(self, rpm: int):
+        self._rpm = max(0, int(rpm))
+        self._window_sec = 60.0
+        self._lock = Lock()
+        self._buckets: dict[str, list[float]] = defaultdict(list)
+
+    def enabled(self) -> bool:
+        return self._rpm > 0
+
+    def check(self, producer: str) -> tuple[bool, int]:
+        if not self.enabled():
+            return (True, 0)
+        now = time.time()
+        with self._lock:
+            bucket = self._buckets[producer]
+            cutoff = now - self._window_sec
+            # Keep only points in current window.
+            i = 0
+            while i < len(bucket) and bucket[i] < cutoff:
+                i += 1
+            if i:
+                del bucket[:i]
+            if len(bucket) >= self._rpm:
+                retry_after = max(1, int(self._window_sec - (now - bucket[0])))
+                return (False, retry_after)
+            bucket.append(now)
+            return (True, 0)

--- a/src/collector/app/routes.py
+++ b/src/collector/app/routes.py
@@ -17,6 +17,7 @@ from .events import build_subject, normalize_event_type
 from .mapping import normalize_payload, validate_alarm_mapping
 from .observability import OutcomeStats
 from .publisher import EventPublisher, PublishUnavailableError
+from .rate_limit import ProducerRateLimiter
 from .repository import IdempotentStore
 from .snapshot import MonitorSnapshotStore
 from .storage import TimescaleWriter, TimescaleWriteError
@@ -24,6 +25,7 @@ from .storage import TimescaleWriter, TimescaleWriteError
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/ingest", tags=["ingest"])
+router_v2 = APIRouter(prefix="/api/v2/ingest", tags=["ingest"])
 
 ALLOWED_KINDS = {"node_metric", "link_metric", "flow", "alarm", "node-metric", "link-metric"}
 
@@ -60,8 +62,23 @@ def _get_ts_writer(request: Request) -> TimescaleWriter | None:
     return request.app.state.ts_writer
 
 
+def _get_rate_limiter(request: Request) -> ProducerRateLimiter:
+    return request.app.state.rate_limiter
+
+
 def _build_trace_id(request: Request) -> str:
     return request.headers.get("x-trace-id") or request.headers.get("x-request-id") or uuid4().hex
+
+
+def _producer_id(request: Request, payload: dict[str, Any]) -> str:
+    pid = (
+        request.headers.get("x-producer-id")
+        or str(payload.get("producer_id") or "").strip()
+        or str(payload.get("source_id") or "").strip()
+    )
+    if pid:
+        return pid
+    return request.client.host if request.client else "unknown"
 
 
 def _audit(
@@ -86,9 +103,11 @@ def _error_response(
     error_code: str,
     error_message: str,
     trace_id: str,
+    headers: dict[str, str] | None = None,
 ) -> JSONResponse:
     return JSONResponse(
         status_code=status_code,
+        headers=headers or None,
         content={
             "status": "error",
             "error_code": error_code,
@@ -98,8 +117,7 @@ def _error_response(
     )
 
 
-@router.post("/{kind}")
-async def ingest(
+async def _ingest_impl(
     kind: str,
     request: Request,
     payload: dict[str, Any],
@@ -111,13 +129,15 @@ async def ingest(
     snapshot_store: MonitorSnapshotStore = Depends(_get_snapshot_store),
     failed_events: FailedEventStore = Depends(_get_failed_events_store),
     ts_writer: TimescaleWriter | None = Depends(_get_ts_writer),
+    rate_limiter: ProducerRateLimiter = Depends(_get_rate_limiter),
 ):
     trace_id = _build_trace_id(request)
     event_type = _normalize_kind(kind)
     message_id = str(payload.get("message_id") or "")
+    producer = _producer_id(request, payload)
 
     if kind not in ALLOWED_KINDS:
-        stats.record("INVALID_KIND")
+        stats.record("INVALID_KIND", event_type=event_type, producer=producer)
         _audit(request, trace_id, "INVALID_KIND", event_type, message_id)
         return _error_response(
             status_code=400,
@@ -130,20 +150,33 @@ async def ingest(
     try:
         validate_api_token(headers, config.api_token)
     except HTTPException as exc:
-        stats.record("UNAUTHORIZED")
-        _audit(request, trace_id, "UNAUTHORIZED", event_type, message_id)
+        error_code = "AUTH_TOKEN_MISSING" if exc.status_code == 401 else "AUTH_TOKEN_INVALID"
+        stats.record(error_code, event_type=event_type, producer=producer)
+        _audit(request, trace_id, error_code, event_type, message_id)
         return _error_response(
             status_code=exc.status_code,
-            error_code="UNAUTHORIZED",
+            error_code=error_code,
             error_message="鉴权失败",
             trace_id=trace_id,
+        )
+
+    allowed, retry_after = rate_limiter.check(producer)
+    if not allowed:
+        stats.record("RATE_LIMITED", event_type=event_type, producer=producer)
+        _audit(request, trace_id, "RATE_LIMITED", event_type, message_id)
+        return _error_response(
+            status_code=429,
+            error_code="RATE_LIMITED",
+            error_message=f"producer 请求过快: {producer}",
+            trace_id=trace_id,
+            headers={"Retry-After": str(retry_after)},
         )
 
     normalize_payload(event_type, payload)
     try:
         validate_payload(event_type, payload)
     except ContractError as e:
-        stats.record(e.code)
+        stats.record(e.code, event_type=event_type, producer=producer)
         _audit(request, trace_id, e.code, event_type, message_id)
         return _error_response(
             status_code=422,
@@ -155,7 +188,7 @@ async def ingest(
     mapping_error = validate_alarm_mapping(event_type, payload, snapshot_store)
     if mapping_error is not None:
         error_code, error_message = mapping_error
-        stats.record(error_code)
+        stats.record(error_code, event_type=event_type, producer=producer)
         _audit(request, trace_id, error_code, event_type, message_id)
         return _error_response(
             status_code=422,
@@ -165,7 +198,7 @@ async def ingest(
         )
 
     if dedup.is_duplicate(message_id):
-        stats.record("DUPLICATE")
+        stats.record("DUPLICATE", event_type=event_type, producer=producer)
         _audit(request, trace_id, "DUPLICATE", event_type, message_id)
         return {
             "status": "duplicate",
@@ -190,7 +223,7 @@ async def ingest(
     try:
         await publisher.publish(topic, event_message)
     except PublishUnavailableError:
-        stats.record("NATS_UNAVAILABLE")
+        stats.record("NATS_UNAVAILABLE", event_type=event_type, producer=producer)
         _audit(request, trace_id, "NATS_UNAVAILABLE", event_type, message_id)
         failed_events.record(
             trace_id=trace_id,
@@ -211,7 +244,7 @@ async def ingest(
         try:
             await asyncio.to_thread(ts_writer.write_event, event_type, payload)
         except TimescaleWriteError as e:
-            stats.record("DB_WRITE_FAILED")
+            stats.record("DB_WRITE_FAILED", event_type=event_type, producer=producer)
             _audit(request, trace_id, "DB_WRITE_FAILED", event_type, message_id)
             failed_events.record(
                 trace_id=trace_id,
@@ -220,7 +253,7 @@ async def ingest(
                 error_code="DB_WRITE_FAILED",
                 error_message=str(e),
             )
-    stats.record("OK")
+    stats.record("OK", event_type=event_type, producer=producer)
     _audit(request, trace_id, "OK", event_type, message_id)
     return {
         "status": "ok",
@@ -228,3 +261,65 @@ async def ingest(
         "message_id": message_id,
         "trace_id": trace_id,
     }
+
+
+@router.post("/{kind}")
+async def ingest_v1(
+    kind: str,
+    request: Request,
+    payload: dict[str, Any],
+    x_api_token: str | None = Header(default=None),
+    config: CollectorConfig = Depends(_get_config),
+    publisher: EventPublisher = Depends(_get_publisher),
+    dedup: IdempotentStore = Depends(_get_dedup),
+    stats: OutcomeStats = Depends(_get_stats),
+    snapshot_store: MonitorSnapshotStore = Depends(_get_snapshot_store),
+    failed_events: FailedEventStore = Depends(_get_failed_events_store),
+    ts_writer: TimescaleWriter | None = Depends(_get_ts_writer),
+    rate_limiter: ProducerRateLimiter = Depends(_get_rate_limiter),
+):
+    return await _ingest_impl(
+        kind=kind,
+        request=request,
+        payload=payload,
+        x_api_token=x_api_token,
+        config=config,
+        publisher=publisher,
+        dedup=dedup,
+        stats=stats,
+        snapshot_store=snapshot_store,
+        failed_events=failed_events,
+        ts_writer=ts_writer,
+        rate_limiter=rate_limiter,
+    )
+
+
+@router_v2.post("/{kind}")
+async def ingest_v2(
+    kind: str,
+    request: Request,
+    payload: dict[str, Any],
+    x_api_token: str | None = Header(default=None),
+    config: CollectorConfig = Depends(_get_config),
+    publisher: EventPublisher = Depends(_get_publisher),
+    dedup: IdempotentStore = Depends(_get_dedup),
+    stats: OutcomeStats = Depends(_get_stats),
+    snapshot_store: MonitorSnapshotStore = Depends(_get_snapshot_store),
+    failed_events: FailedEventStore = Depends(_get_failed_events_store),
+    ts_writer: TimescaleWriter | None = Depends(_get_ts_writer),
+    rate_limiter: ProducerRateLimiter = Depends(_get_rate_limiter),
+):
+    return await _ingest_impl(
+        kind=kind,
+        request=request,
+        payload=payload,
+        x_api_token=x_api_token,
+        config=config,
+        publisher=publisher,
+        dedup=dedup,
+        stats=stats,
+        snapshot_store=snapshot_store,
+        failed_events=failed_events,
+        ts_writer=ts_writer,
+        rate_limiter=rate_limiter,
+    )

--- a/src/collector/config.example.yaml
+++ b/src/collector/config.example.yaml
@@ -10,3 +10,4 @@ failed_events_audit_file: /tmp/collector_failed_events.jsonl
 tsdb_enabled: true
 tsdb_dsn: postgresql://monitor:monitor123@monitor_timescaledb:5432/monitor
 tsdb_schema: monitor_ts
+producer_rate_limit_rpm: 0


### PR DESCRIPTION
## 背景与目标
实现 I-030：统一接入网关 v2，支持 schema_version v1/v2、producer 限流、幂等冲突按维度可观测。

## 变更内容
- 新增 `/api/v2/ingest/{kind}` 路由，与 v1 并行
- `schema_version` 支持 `monitor.v1|monitor.v2`
- 新增按 producer 的每分钟限流（`PRODUCER_RATE_LIMIT_RPM`）
- 鉴权错误码细分：`AUTH_TOKEN_MISSING` / `AUTH_TOKEN_INVALID`
- `metrics` 增加 `duplicate_by_event_type` 与 `duplicate_by_producer`

## 验证方式与结果
- v2 入站：200
- 缺失 token：401 + `AUTH_TOKEN_MISSING`
- 限流（rpm=2）：第3次请求返回 429 + `RATE_LIMITED`
- duplicate：返回 `status=duplicate` 且 metrics 中按 event_type/producer 计数

## 风险与回滚方案
- 风险：限流阈值配置过低会影响吞吐
- 回滚：将 `PRODUCER_RATE_LIMIT_RPM=0` 关闭限流

## 影响范围
- collector 入站 API、契约校验、观测指标
