### PR TITLE
[I-031] 事件总线治理（Topic/Retry/DLQ）

### DIFF
--- a/src/collector/README.md
+++ b/src/collector/README.md
@@ -15,6 +15,7 @@
   - 支持条件请求：`If-None-Match` 命中后返回 `304`
 - `GET /api/v1/ops/failed-events`：查看失败事件审计与状态
 - `POST /api/v1/ops/failed-events/replay`：手动重放失败事件
+  - 参数：`target=original|dlq`（默认 `original`）
 - `POST /api/v1/ingest/{kind}`：上报入口
 - `POST /api/v2/ingest/{kind}`：v2 上报入口（与 v1 并行）
   - kind 取值：`node_metric`、`node-metric`、`link_metric`、`link-metric`、`flow`、`alarm`
@@ -56,6 +57,19 @@
 - `TSDB_DSN`：Timescale 连接串
 - `TSDB_SCHEMA`：写入 schema（默认 `monitor_ts`）
 - `PRODUCER_RATE_LIMIT_RPM`：按 producer 每分钟限流阈值（`0` 表示关闭）
+
+## Topic 规范（I-031）
+- 事件主题格式：`{environment}.{domain}.{entity}.{version}`
+- 示例：`dev.raw.node_metric.v1`、`dev.raw.link_metric.v2`
+- DLQ 主题格式：`{environment}.dlq.{domain}.{entity}.{version}`
+- 示例：`dev.dlq.raw.node_metric.v1`
+
+## DLQ 与回放
+- NATS 发布失败：失败事件进入 failed-events 审计（状态 `pending`）
+- DB 写入失败：失败事件进入审计，并尝试发布到对应 DLQ 主题
+- 手动回放：
+  - `POST /api/v1/ops/failed-events/replay?target=original`
+  - `POST /api/v1/ops/failed-events/replay?target=dlq`
 
 ## Timescale 写入
 - 入站事件在发布 NATS 成功后会尝试写入 Timescale（四类表）

--- a/src/collector/README.md
+++ b/src/collector/README.md
@@ -16,20 +16,23 @@
 - `GET /api/v1/ops/failed-events`：查看失败事件审计与状态
 - `POST /api/v1/ops/failed-events/replay`：手动重放失败事件
 - `POST /api/v1/ingest/{kind}`：上报入口
+- `POST /api/v2/ingest/{kind}`：v2 上报入口（与 v1 并行）
   - kind 取值：`node_metric`、`node-metric`、`link_metric`、`link-metric`、`flow`、`alarm`
 - Header：
   - `x-api-token`：上报鉴权
 
 ## 必填字段
 - 所有事件必须包含：
-  - `schema_version=monitor.v1`
+  - `schema_version=monitor.v1|monitor.v2`
   - `message_id`
 - `timestamp` 缺省可由服务端补齐
 
 ## 错误码
 - `INVALID_PAYLOAD`：字段校验失败
 - `INVALID_KIND`：不支持事件类型
-- `UNAUTHORIZED`：鉴权失败
+- `AUTH_TOKEN_MISSING`：缺少 token
+- `AUTH_TOKEN_INVALID`：token 不匹配
+- `RATE_LIMITED`：同一 producer 触发限流
 - `NATS_UNAVAILABLE`：事件总线不可用
 
 ## 幂等策略
@@ -52,6 +55,7 @@
 - `TSDB_ENABLED`：是否启用 Timescale 写入（默认 `true`）
 - `TSDB_DSN`：Timescale 连接串
 - `TSDB_SCHEMA`：写入 schema（默认 `monitor_ts`）
+- `PRODUCER_RATE_LIMIT_RPM`：按 producer 每分钟限流阈值（`0` 表示关闭）
 
 ## Timescale 写入
 - 入站事件在发布 NATS 成功后会尝试写入 Timescale（四类表）

--- a/src/collector/app/config.py
+++ b/src/collector/app/config.py
@@ -23,6 +23,7 @@ class CollectorConfig:
     tsdb_enabled: bool
     tsdb_dsn: str
     tsdb_schema: str
+    producer_rate_limit_rpm: int
 
 
 def load_config(path: str = "/app/config.example.yaml") -> CollectorConfig:
@@ -56,4 +57,7 @@ def load_config(path: str = "/app/config.example.yaml") -> CollectorConfig:
             raw.get("tsdb_dsn", "postgresql://monitor:monitor123@monitor_timescaledb:5432/monitor"),
         ),
         tsdb_schema=os.environ.get("TSDB_SCHEMA", raw.get("tsdb_schema", "monitor_ts")),
+        producer_rate_limit_rpm=int(
+            os.environ.get("PRODUCER_RATE_LIMIT_RPM", raw.get("producer_rate_limit_rpm", 0))
+        ),
     )

--- a/src/collector/app/contract.py
+++ b/src/collector/app/contract.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-SCHEMA_VERSION = "monitor.v1"
+SCHEMA_VERSIONS = {"monitor.v1", "monitor.v2"}
 
 ALLOWED_NODE_STATUS = {"UP", "DOWN", "DEGRADED"}
 ALLOWED_LINK_STATE = {"UP", "DOWN", "DEGRADED"}
@@ -40,8 +40,8 @@ def _check_ratio(payload: dict[str, Any], key: str) -> None:
 def validate_common(payload: dict[str, Any]) -> None:
     _require(payload, "schema_version")
     _require(payload, "message_id")
-    if payload.get("schema_version") != SCHEMA_VERSION:
-        raise ContractError("INVALID_PAYLOAD", "schema_version 必须为 monitor.v1")
+    if payload.get("schema_version") not in SCHEMA_VERSIONS:
+        raise ContractError("INVALID_PAYLOAD", "schema_version 仅支持 monitor.v1|monitor.v2")
 
 
 def validate_payload(event_type: str, payload: dict[str, Any]) -> None:

--- a/src/collector/app/events.py
+++ b/src/collector/app/events.py
@@ -38,4 +38,23 @@ def normalize_event_type(raw_type: str) -> str:
 
 
 def build_subject(environment: str, category: str, event_type: str) -> str:
-    return f"{environment}.{category}.{normalize_event_type(event_type)}"
+    entity = normalize_event_type(event_type)
+    return f"{environment}.{category}.{entity}.v1"
+
+
+def build_versioned_subject(environment: str, domain: str, event_type: str, schema_version: str | None) -> str:
+    entity = normalize_event_type(event_type)
+    version = "v1"
+    raw = str(schema_version or "").strip().lower()
+    if raw.startswith("monitor.v"):
+        version = "v" + raw.split("monitor.v", 1)[1]
+    return f"{environment}.{domain}.{entity}.{version}"
+
+
+def build_dlq_subject(environment: str, domain: str, event_type: str, schema_version: str | None) -> str:
+    entity = normalize_event_type(event_type)
+    version = "v1"
+    raw = str(schema_version or "").strip().lower()
+    if raw.startswith("monitor.v"):
+        version = "v" + raw.split("monitor.v", 1)[1]
+    return f"{environment}.dlq.{domain}.{entity}.{version}"

--- a/src/collector/app/failed_events.py
+++ b/src/collector/app/failed_events.py
@@ -21,6 +21,10 @@ class FailedEvent:
     trace_id: str
     subject: str
     payload: dict[str, Any]
+    producer: str
+    event_type: str
+    schema_version: str
+    dlq_subject: str
     error_code: str
     error_message: str
     status: str = "pending"
@@ -35,6 +39,10 @@ class FailedEvent:
             "trace_id": self.trace_id,
             "subject": self.subject,
             "payload": self.payload,
+            "producer": self.producer,
+            "event_type": self.event_type,
+            "schema_version": self.schema_version,
+            "dlq_subject": self.dlq_subject,
             "error_code": self.error_code,
             "error_message": self.error_message,
             "status": self.status,
@@ -69,6 +77,10 @@ class FailedEventStore:
         trace_id: str,
         subject: str,
         payload: dict[str, Any],
+        producer: str,
+        event_type: str,
+        schema_version: str,
+        dlq_subject: str,
         error_code: str,
         error_message: str,
     ) -> dict[str, Any]:
@@ -78,6 +90,10 @@ class FailedEventStore:
             trace_id=trace_id,
             subject=subject,
             payload=payload,
+            producer=producer,
+            event_type=event_type,
+            schema_version=schema_version,
+            dlq_subject=dlq_subject,
             error_code=error_code,
             error_message=error_message,
         )
@@ -141,9 +157,11 @@ class FailedEventStore:
         with self._lock:
             total = len(self._events)
             by_status = {"pending": 0, "failed": 0, "replayed": 0}
+            by_error_code: dict[str, int] = {}
             for event in self._events.values():
                 if event.status in by_status:
                     by_status[event.status] += 1
                 else:
                     by_status[event.status] = by_status.get(event.status, 0) + 1
-        return {"total": total, "by_status": by_status}
+                by_error_code[event.error_code] = by_error_code.get(event.error_code, 0) + 1
+        return {"total": total, "by_status": by_status, "by_error_code": by_error_code}

--- a/src/collector/app/main.py
+++ b/src/collector/app/main.py
@@ -64,7 +64,11 @@ def create_app() -> FastAPI:
 
     @app.get("/metrics")
     async def metrics() -> dict[str, object]:
-        return app.state.stats.snapshot()
+        return {
+            **app.state.stats.snapshot(),
+            "publisher": app.state.publisher.stats(),
+            "failed_events": app.state.failed_events.summary(),
+        }
 
     @app.get("/api/v1/monitor/snapshot")
     async def monitor_snapshot(
@@ -189,7 +193,10 @@ def create_app() -> FastAPI:
         }
 
     @app.post("/api/v1/ops/failed-events/replay")
-    async def replay_failed_events(limit: int = 50) -> dict[str, object]:
+    async def replay_failed_events(limit: int = 50, target: str = "original") -> dict[str, object]:
+        replay_target = str(target or "original").strip().lower()
+        if replay_target not in {"original", "dlq"}:
+            raise HTTPException(status_code=422, detail="target 仅支持 original|dlq")
         ids = app.state.failed_events.pending_event_ids(limit=limit)
         attempted = 0
         replayed = 0
@@ -201,13 +208,28 @@ def create_app() -> FastAPI:
                 continue
             attempted += 1
             try:
+                subject = str(event.get("subject") or "")
+                payload = dict(event.get("payload") or {})
+                if replay_target == "dlq":
+                    subject = str(event.get("dlq_subject") or subject)
+                    payload = {
+                        "source": "manual-replay",
+                        "trace_id": event.get("trace_id"),
+                        "event_type": event.get("event_type"),
+                        "schema_version": event.get("schema_version"),
+                        "producer": event.get("producer"),
+                        "error_code": event.get("error_code"),
+                        "error_message": event.get("error_message"),
+                        "failed_subject": event.get("subject"),
+                        "payload": event.get("payload"),
+                    }
                 await app.state.publisher.publish(
-                    str(event.get("subject") or ""),
-                    dict(event.get("payload") or {}),
+                    subject,
+                    payload,
                 )
                 app.state.failed_events.mark_replay(event_id, success=True)
                 replayed += 1
-                details.append({"id": event_id, "status": "replayed"})
+                details.append({"id": event_id, "status": "replayed", "target": replay_target, "subject": subject})
             except Exception as exc:  # noqa: BLE001
                 app.state.failed_events.mark_replay(event_id, success=False, replay_error=str(exc))
                 failed += 1
@@ -216,6 +238,7 @@ def create_app() -> FastAPI:
             "attempted": attempted,
             "replayed": replayed,
             "failed": failed,
+            "target": replay_target,
             "details": details,
             "summary": app.state.failed_events.summary(),
         }

--- a/src/collector/app/main.py
+++ b/src/collector/app/main.py
@@ -9,8 +9,9 @@ from .config import load_config
 from .failed_events import FailedEventStore
 from .observability import OutcomeStats
 from .publisher import EventPublisher
+from .rate_limit import ProducerRateLimiter
 from .repository import IdempotentStore
-from .routes import router
+from .routes import router, router_v2
 from .snapshot import MonitorSnapshotStore
 from .storage import TimescaleWriter
 
@@ -20,6 +21,7 @@ def create_app() -> FastAPI:
 
     app = FastAPI(title="net-analysis collector")
     app.include_router(router)
+    app.include_router(router_v2)
 
     app.state.config = config
     app.state.publisher = EventPublisher(
@@ -34,6 +36,7 @@ def create_app() -> FastAPI:
         max_items=config.failed_events_max_items,
         audit_file_path=config.failed_events_audit_file,
     )
+    app.state.rate_limiter = ProducerRateLimiter(rpm=config.producer_rate_limit_rpm)
     app.state.ts_writer = None
     if config.tsdb_enabled:
         app.state.ts_writer = TimescaleWriter(config.tsdb_dsn, schema=config.tsdb_schema)

--- a/src/collector/app/observability.py
+++ b/src/collector/app/observability.py
@@ -8,14 +8,23 @@ class OutcomeStats:
     def __init__(self) -> None:
         self._lock = Lock()
         self._counter: Counter[str] = Counter()
+        self._dup_by_event_type: Counter[str] = Counter()
+        self._dup_by_producer: Counter[str] = Counter()
 
-    def record(self, code: str) -> None:
+    def record(self, code: str, event_type: str | None = None, producer: str | None = None) -> None:
         with self._lock:
             self._counter[code] += 1
+            if code == "DUPLICATE":
+                if event_type:
+                    self._dup_by_event_type[event_type] += 1
+                if producer:
+                    self._dup_by_producer[producer] += 1
 
     def snapshot(self) -> dict[str, object]:
         with self._lock:
             counts = dict(self._counter)
+            dup_event = dict(self._dup_by_event_type)
+            dup_producer = dict(self._dup_by_producer)
 
         total = sum(counts.values())
         ok = counts.get("OK", 0)
@@ -32,4 +41,6 @@ class OutcomeStats:
             "success_rate": success_rate,
             "fail_rate": fail_rate,
             "by_code": counts,
+            "duplicate_by_event_type": dup_event,
+            "duplicate_by_producer": dup_producer,
         }

--- a/src/collector/app/publisher.py
+++ b/src/collector/app/publisher.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from threading import Lock
 from typing import Any
 
 from nats.aio.client import Client as NATS
@@ -17,6 +18,10 @@ class EventPublisher:
         self._conn = NATS()
         self._retries = max(0, retries)
         self._retry_backoff_ms = max(1, retry_backoff_ms)
+        self._lock = Lock()
+        self._publish_ok = 0
+        self._publish_fail = 0
+        self._publish_retry = 0
 
     async def connect(self) -> None:
         await self._conn.connect(servers=[self._url])
@@ -31,13 +36,29 @@ class EventPublisher:
     async def publish(self, subject: str, payload: dict[str, Any]) -> None:
         data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
         if not self._conn.is_connected:
+            with self._lock:
+                self._publish_fail += 1
             raise PublishUnavailableError("nats connection is not ready")
         attempts = self._retries + 1
         for attempt in range(attempts):
             try:
                 await self._conn.publish(subject=subject, payload=data)
+                with self._lock:
+                    self._publish_ok += 1
                 return
             except Exception as exc:
                 if attempt >= attempts - 1:
+                    with self._lock:
+                        self._publish_fail += 1
                     raise PublishUnavailableError("failed to publish event") from exc
+                with self._lock:
+                    self._publish_retry += 1
                 await asyncio.sleep(self._retry_backoff_ms / 1000.0)
+
+    def stats(self) -> dict[str, int]:
+        with self._lock:
+            return {
+                "publish_ok_total": self._publish_ok,
+                "publish_fail_total": self._publish_fail,
+                "publish_retry_total": self._publish_retry,
+            }

--- a/src/collector/app/rate_limit.py
+++ b/src/collector/app/rate_limit.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+from threading import Lock
+
+
+class ProducerRateLimiter:
+    def __init__(self, rpm: int):
+        self._rpm = max(0, int(rpm))
+        self._window_sec = 60.0
+        self._lock = Lock()
+        self._buckets: dict[str, list[float]] = defaultdict(list)
+
+    def enabled(self) -> bool:
+        return self._rpm > 0
+
+    def check(self, producer: str) -> tuple[bool, int]:
+        if not self.enabled():
+            return (True, 0)
+        now = time.time()
+        with self._lock:
+            bucket = self._buckets[producer]
+            cutoff = now - self._window_sec
+            # Keep only points in current window.
+            i = 0
+            while i < len(bucket) and bucket[i] < cutoff:
+                i += 1
+            if i:
+                del bucket[:i]
+            if len(bucket) >= self._rpm:
+                retry_after = max(1, int(self._window_sec - (now - bucket[0])))
+                return (False, retry_after)
+            bucket.append(now)
+            return (True, 0)

--- a/src/collector/app/routes.py
+++ b/src/collector/app/routes.py
@@ -17,6 +17,7 @@ from .events import build_subject, normalize_event_type
 from .mapping import normalize_payload, validate_alarm_mapping
 from .observability import OutcomeStats
 from .publisher import EventPublisher, PublishUnavailableError
+from .rate_limit import ProducerRateLimiter
 from .repository import IdempotentStore
 from .snapshot import MonitorSnapshotStore
 from .storage import TimescaleWriter, TimescaleWriteError
@@ -24,6 +25,7 @@ from .storage import TimescaleWriter, TimescaleWriteError
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/ingest", tags=["ingest"])
+router_v2 = APIRouter(prefix="/api/v2/ingest", tags=["ingest"])
 
 ALLOWED_KINDS = {"node_metric", "link_metric", "flow", "alarm", "node-metric", "link-metric"}
 
@@ -60,8 +62,23 @@ def _get_ts_writer(request: Request) -> TimescaleWriter | None:
     return request.app.state.ts_writer
 
 
+def _get_rate_limiter(request: Request) -> ProducerRateLimiter:
+    return request.app.state.rate_limiter
+
+
 def _build_trace_id(request: Request) -> str:
     return request.headers.get("x-trace-id") or request.headers.get("x-request-id") or uuid4().hex
+
+
+def _producer_id(request: Request, payload: dict[str, Any]) -> str:
+    pid = (
+        request.headers.get("x-producer-id")
+        or str(payload.get("producer_id") or "").strip()
+        or str(payload.get("source_id") or "").strip()
+    )
+    if pid:
+        return pid
+    return request.client.host if request.client else "unknown"
 
 
 def _audit(
@@ -86,9 +103,11 @@ def _error_response(
     error_code: str,
     error_message: str,
     trace_id: str,
+    headers: dict[str, str] | None = None,
 ) -> JSONResponse:
     return JSONResponse(
         status_code=status_code,
+        headers=headers or None,
         content={
             "status": "error",
             "error_code": error_code,
@@ -98,8 +117,7 @@ def _error_response(
     )
 
 
-@router.post("/{kind}")
-async def ingest(
+async def _ingest_impl(
     kind: str,
     request: Request,
     payload: dict[str, Any],
@@ -111,13 +129,15 @@ async def ingest(
     snapshot_store: MonitorSnapshotStore = Depends(_get_snapshot_store),
     failed_events: FailedEventStore = Depends(_get_failed_events_store),
     ts_writer: TimescaleWriter | None = Depends(_get_ts_writer),
+    rate_limiter: ProducerRateLimiter = Depends(_get_rate_limiter),
 ):
     trace_id = _build_trace_id(request)
     event_type = _normalize_kind(kind)
     message_id = str(payload.get("message_id") or "")
+    producer = _producer_id(request, payload)
 
     if kind not in ALLOWED_KINDS:
-        stats.record("INVALID_KIND")
+        stats.record("INVALID_KIND", event_type=event_type, producer=producer)
         _audit(request, trace_id, "INVALID_KIND", event_type, message_id)
         return _error_response(
             status_code=400,
@@ -130,20 +150,33 @@ async def ingest(
     try:
         validate_api_token(headers, config.api_token)
     except HTTPException as exc:
-        stats.record("UNAUTHORIZED")
-        _audit(request, trace_id, "UNAUTHORIZED", event_type, message_id)
+        error_code = "AUTH_TOKEN_MISSING" if exc.status_code == 401 else "AUTH_TOKEN_INVALID"
+        stats.record(error_code, event_type=event_type, producer=producer)
+        _audit(request, trace_id, error_code, event_type, message_id)
         return _error_response(
             status_code=exc.status_code,
-            error_code="UNAUTHORIZED",
+            error_code=error_code,
             error_message="鉴权失败",
             trace_id=trace_id,
+        )
+
+    allowed, retry_after = rate_limiter.check(producer)
+    if not allowed:
+        stats.record("RATE_LIMITED", event_type=event_type, producer=producer)
+        _audit(request, trace_id, "RATE_LIMITED", event_type, message_id)
+        return _error_response(
+            status_code=429,
+            error_code="RATE_LIMITED",
+            error_message=f"producer 请求过快: {producer}",
+            trace_id=trace_id,
+            headers={"Retry-After": str(retry_after)},
         )
 
     normalize_payload(event_type, payload)
     try:
         validate_payload(event_type, payload)
     except ContractError as e:
-        stats.record(e.code)
+        stats.record(e.code, event_type=event_type, producer=producer)
         _audit(request, trace_id, e.code, event_type, message_id)
         return _error_response(
             status_code=422,
@@ -155,7 +188,7 @@ async def ingest(
     mapping_error = validate_alarm_mapping(event_type, payload, snapshot_store)
     if mapping_error is not None:
         error_code, error_message = mapping_error
-        stats.record(error_code)
+        stats.record(error_code, event_type=event_type, producer=producer)
         _audit(request, trace_id, error_code, event_type, message_id)
         return _error_response(
             status_code=422,
@@ -165,7 +198,7 @@ async def ingest(
         )
 
     if dedup.is_duplicate(message_id):
-        stats.record("DUPLICATE")
+        stats.record("DUPLICATE", event_type=event_type, producer=producer)
         _audit(request, trace_id, "DUPLICATE", event_type, message_id)
         return {
             "status": "duplicate",
@@ -190,7 +223,7 @@ async def ingest(
     try:
         await publisher.publish(topic, event_message)
     except PublishUnavailableError:
-        stats.record("NATS_UNAVAILABLE")
+        stats.record("NATS_UNAVAILABLE", event_type=event_type, producer=producer)
         _audit(request, trace_id, "NATS_UNAVAILABLE", event_type, message_id)
         failed_events.record(
             trace_id=trace_id,
@@ -211,7 +244,7 @@ async def ingest(
         try:
             await asyncio.to_thread(ts_writer.write_event, event_type, payload)
         except TimescaleWriteError as e:
-            stats.record("DB_WRITE_FAILED")
+            stats.record("DB_WRITE_FAILED", event_type=event_type, producer=producer)
             _audit(request, trace_id, "DB_WRITE_FAILED", event_type, message_id)
             failed_events.record(
                 trace_id=trace_id,
@@ -220,7 +253,7 @@ async def ingest(
                 error_code="DB_WRITE_FAILED",
                 error_message=str(e),
             )
-    stats.record("OK")
+    stats.record("OK", event_type=event_type, producer=producer)
     _audit(request, trace_id, "OK", event_type, message_id)
     return {
         "status": "ok",
@@ -228,3 +261,65 @@ async def ingest(
         "message_id": message_id,
         "trace_id": trace_id,
     }
+
+
+@router.post("/{kind}")
+async def ingest_v1(
+    kind: str,
+    request: Request,
+    payload: dict[str, Any],
+    x_api_token: str | None = Header(default=None),
+    config: CollectorConfig = Depends(_get_config),
+    publisher: EventPublisher = Depends(_get_publisher),
+    dedup: IdempotentStore = Depends(_get_dedup),
+    stats: OutcomeStats = Depends(_get_stats),
+    snapshot_store: MonitorSnapshotStore = Depends(_get_snapshot_store),
+    failed_events: FailedEventStore = Depends(_get_failed_events_store),
+    ts_writer: TimescaleWriter | None = Depends(_get_ts_writer),
+    rate_limiter: ProducerRateLimiter = Depends(_get_rate_limiter),
+):
+    return await _ingest_impl(
+        kind=kind,
+        request=request,
+        payload=payload,
+        x_api_token=x_api_token,
+        config=config,
+        publisher=publisher,
+        dedup=dedup,
+        stats=stats,
+        snapshot_store=snapshot_store,
+        failed_events=failed_events,
+        ts_writer=ts_writer,
+        rate_limiter=rate_limiter,
+    )
+
+
+@router_v2.post("/{kind}")
+async def ingest_v2(
+    kind: str,
+    request: Request,
+    payload: dict[str, Any],
+    x_api_token: str | None = Header(default=None),
+    config: CollectorConfig = Depends(_get_config),
+    publisher: EventPublisher = Depends(_get_publisher),
+    dedup: IdempotentStore = Depends(_get_dedup),
+    stats: OutcomeStats = Depends(_get_stats),
+    snapshot_store: MonitorSnapshotStore = Depends(_get_snapshot_store),
+    failed_events: FailedEventStore = Depends(_get_failed_events_store),
+    ts_writer: TimescaleWriter | None = Depends(_get_ts_writer),
+    rate_limiter: ProducerRateLimiter = Depends(_get_rate_limiter),
+):
+    return await _ingest_impl(
+        kind=kind,
+        request=request,
+        payload=payload,
+        x_api_token=x_api_token,
+        config=config,
+        publisher=publisher,
+        dedup=dedup,
+        stats=stats,
+        snapshot_store=snapshot_store,
+        failed_events=failed_events,
+        ts_writer=ts_writer,
+        rate_limiter=rate_limiter,
+    )

--- a/src/collector/app/routes.py
+++ b/src/collector/app/routes.py
@@ -13,7 +13,7 @@ from .config import CollectorConfig
 from .contract import ContractError, validate_payload
 from .failed_events import FailedEventStore
 from .middleware.auth import validate_api_token
-from .events import build_subject, normalize_event_type
+from .events import build_dlq_subject, build_versioned_subject, normalize_event_type
 from .mapping import normalize_payload, validate_alarm_mapping
 from .observability import OutcomeStats
 from .publisher import EventPublisher, PublishUnavailableError
@@ -135,6 +135,7 @@ async def _ingest_impl(
     event_type = _normalize_kind(kind)
     message_id = str(payload.get("message_id") or "")
     producer = _producer_id(request, payload)
+    schema_version = str(payload.get("schema_version") or "monitor.v1")
 
     if kind not in ALLOWED_KINDS:
         stats.record("INVALID_KIND", event_type=event_type, producer=producer)
@@ -210,7 +211,8 @@ async def _ingest_impl(
     if "timestamp" not in payload:
         payload["timestamp"] = datetime.now(timezone.utc).isoformat()
 
-    topic = build_subject(config.environment, config.topic_prefix, event_type)
+    topic = build_versioned_subject(config.environment, config.topic_prefix, event_type, schema_version)
+    dlq_subject = build_dlq_subject(config.environment, config.topic_prefix, event_type, schema_version)
     event_message = {
         "event_type": event_type,
         "payload": payload,
@@ -229,6 +231,10 @@ async def _ingest_impl(
             trace_id=trace_id,
             subject=topic,
             payload=event_message,
+            producer=producer,
+            event_type=event_type,
+            schema_version=schema_version,
+            dlq_subject=dlq_subject,
             error_code="NATS_UNAVAILABLE",
             error_message="事件总线不可用，投递失败",
         )
@@ -250,9 +256,32 @@ async def _ingest_impl(
                 trace_id=trace_id,
                 subject="timescale.write",
                 payload={"event_type": event_type, "payload": payload},
+                producer=producer,
+                event_type=event_type,
+                schema_version=schema_version,
+                dlq_subject=dlq_subject,
                 error_code="DB_WRITE_FAILED",
                 error_message=str(e),
             )
+            # NATS connected but DB write failed: route structured error event to DLQ topic.
+            try:
+                await publisher.publish(
+                    dlq_subject,
+                    {
+                        "event_type": event_type,
+                        "schema_version": schema_version,
+                        "producer": producer,
+                        "trace_id": trace_id,
+                        "error_code": "DB_WRITE_FAILED",
+                        "error_message": str(e),
+                        "failed_subject": topic,
+                        "payload": payload,
+                        "received_at": datetime.now(timezone.utc).isoformat(),
+                    },
+                )
+                stats.record("DLQ_PUBLISHED", event_type=event_type, producer=producer)
+            except PublishUnavailableError:
+                stats.record("DLQ_PUBLISH_FAILED", event_type=event_type, producer=producer)
     stats.record("OK", event_type=event_type, producer=producer)
     _audit(request, trace_id, "OK", event_type, message_id)
     return {

--- a/src/collector/config.example.yaml
+++ b/src/collector/config.example.yaml
@@ -10,3 +10,4 @@ failed_events_audit_file: /tmp/collector_failed_events.jsonl
 tsdb_enabled: true
 tsdb_dsn: postgresql://monitor:monitor123@monitor_timescaledb:5432/monitor
 tsdb_schema: monitor_ts
+producer_rate_limit_rpm: 0


### PR DESCRIPTION
## 背景与目标
实现 I-031：事件总线治理（Topic/Retry/DLQ），统一主题规范并补齐失败回放闭环。

## 变更内容
- 主题升级为版本化格式：`{env}.{domain}.{entity}.{version}`
- 新增 DLQ 主题格式：`{env}.dlq.{domain}.{entity}.{version}`
- 发布器增加可观测统计：`publish_ok_total/publish_fail_total/publish_retry_total`
- 失败事件扩展字段：`producer/event_type/schema_version/dlq_subject`
- `failed-events/replay` 支持 `target=original|dlq`
- `/metrics` 增加 `publisher` 与 `failed_events` 聚合信息

## 验证方式与结果
- v2 入站成功：`/api/v2/ingest/link_metric` 返回 200
- DB失败演练：停掉 timescaledb 后上报，`failed-events` 出现 `DB_WRITE_FAILED` 且携带 `dlq_subject=dev.dlq.raw.node_metric.v2`
- 回放到DLQ：`POST /api/v1/ops/failed-events/replay?target=dlq` 返回 `replayed>0`
- 指标可观测：`/metrics` 返回 `publisher.*`、`failed_events.*`

## 风险与回滚方案
- 风险：主题格式变更会影响老消费者订阅规则
- 回滚：将消费者订阅扩展为兼容旧格式或快速回退该分支

## 影响范围
- collector 事件发布主题规范
- 失败事件审计与回放流程
- 监控指标结构（/metrics）
