### PR TITLE
[I-032] 标准化与映射服务（UID Mapping Service）

### DIFF
--- a/src/collector/README.md
+++ b/src/collector/README.md
@@ -15,6 +15,7 @@
   - 支持条件请求：`If-None-Match` 命中后返回 `304`
 - `GET /api/v1/ops/failed-events`：查看失败事件审计与状态
 - `POST /api/v1/ops/failed-events/replay`：手动重放失败事件
+- `GET /api/v1/monitor/mapping/stats`：UID 映射统计（epoch、映射失败计数、scope_uid 覆盖率）
 - `POST /api/v1/ingest/{kind}`：上报入口
   - kind 取值：`node_metric`、`node-metric`、`link_metric`、`link-metric`、`flow`、`alarm`
 - Header：
@@ -31,9 +32,19 @@
 - `INVALID_KIND`：不支持事件类型
 - `UNAUTHORIZED`：鉴权失败
 - `NATS_UNAVAILABLE`：事件总线不可用
+- `EPOCH_MAPPING_NOT_FOUND`：当前 topology_epoch 未建立映射
+- `UNKNOWN_NODE_UID`：告警 scope_uid 未命中节点映射
+- `UNKNOWN_LINK_UID`：告警 scope_uid 未命中链路映射
 
 ## 幂等策略
 - 按 `message_id` 做去重
+
+## UID 映射规则（I-032）
+- 映射按 `topology_epoch` 隔离
+- `node_metric` 会写入节点 UID 映射
+- `link_metric` 会写入链路 UID 映射
+- `alarm` 写入前必须通过映射校验（node/link）
+- `scope_uid` 覆盖率与映射失败计数可通过 `/metrics` 和 `/api/v1/monitor/mapping/stats` 观测
 
 ## 返回结构
 - success: `{"status":"ok","event_type":"node_metric","message_id":"...","trace_id":"..."}`

--- a/src/collector/app/main.py
+++ b/src/collector/app/main.py
@@ -13,6 +13,7 @@ from .repository import IdempotentStore
 from .routes import router
 from .snapshot import MonitorSnapshotStore
 from .storage import TimescaleWriter
+from .uid_mapping import UidMappingService
 
 
 def create_app() -> FastAPI:
@@ -30,6 +31,7 @@ def create_app() -> FastAPI:
     app.state.idempotent = IdempotentStore(ttl_seconds=config.idempotency_ttl)
     app.state.stats = OutcomeStats()
     app.state.snapshot_store = MonitorSnapshotStore()
+    app.state.uid_mapping = UidMappingService()
     app.state.failed_events = FailedEventStore(
         max_items=config.failed_events_max_items,
         audit_file_path=config.failed_events_audit_file,
@@ -61,7 +63,17 @@ def create_app() -> FastAPI:
 
     @app.get("/metrics")
     async def metrics() -> dict[str, object]:
-        return app.state.stats.snapshot()
+        return {
+            **app.state.stats.snapshot(),
+            "uid_mapping": app.state.uid_mapping.stats(),
+        }
+
+    @app.get("/api/v1/monitor/mapping/stats")
+    async def mapping_stats() -> dict[str, object]:
+        return {
+            "status": "ok",
+            "mapping": app.state.uid_mapping.stats(),
+        }
 
     @app.get("/api/v1/monitor/snapshot")
     async def monitor_snapshot(

--- a/src/collector/app/routes.py
+++ b/src/collector/app/routes.py
@@ -14,12 +14,13 @@ from .contract import ContractError, validate_payload
 from .failed_events import FailedEventStore
 from .middleware.auth import validate_api_token
 from .events import build_subject, normalize_event_type
-from .mapping import normalize_payload, validate_alarm_mapping
+from .mapping import normalize_payload
 from .observability import OutcomeStats
 from .publisher import EventPublisher, PublishUnavailableError
 from .repository import IdempotentStore
 from .snapshot import MonitorSnapshotStore
 from .storage import TimescaleWriter, TimescaleWriteError
+from .uid_mapping import UidMappingService
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +59,10 @@ def _get_failed_events_store(request: Request) -> FailedEventStore:
 
 def _get_ts_writer(request: Request) -> TimescaleWriter | None:
     return request.app.state.ts_writer
+
+
+def _get_mapping_service(request: Request) -> UidMappingService:
+    return request.app.state.uid_mapping
 
 
 def _build_trace_id(request: Request) -> str:
@@ -111,6 +116,7 @@ async def ingest(
     snapshot_store: MonitorSnapshotStore = Depends(_get_snapshot_store),
     failed_events: FailedEventStore = Depends(_get_failed_events_store),
     ts_writer: TimescaleWriter | None = Depends(_get_ts_writer),
+    mapping_service: UidMappingService = Depends(_get_mapping_service),
 ):
     trace_id = _build_trace_id(request)
     event_type = _normalize_kind(kind)
@@ -152,17 +158,22 @@ async def ingest(
             trace_id=trace_id,
         )
 
-    mapping_error = validate_alarm_mapping(event_type, payload, snapshot_store)
-    if mapping_error is not None:
-        error_code, error_message = mapping_error
-        stats.record(error_code)
-        _audit(request, trace_id, error_code, event_type, message_id)
-        return _error_response(
-            status_code=422,
-            error_code=error_code,
-            error_message=error_message,
-            trace_id=trace_id,
-        )
+    if event_type == "node_metric":
+        mapping_service.upsert_node(payload.get("topology_epoch"), str(payload.get("node_uid") or payload.get("node_id") or ""))
+    elif event_type == "link_metric":
+        mapping_service.upsert_link(payload.get("topology_epoch"), str(payload.get("link_uid") or payload.get("link_id") or ""))
+    elif event_type == "alarm":
+        mapping_error = mapping_service.validate_alarm(payload)
+        if mapping_error is not None:
+            error_code, error_message = mapping_error
+            stats.record(error_code)
+            _audit(request, trace_id, error_code, event_type, message_id)
+            return _error_response(
+                status_code=422,
+                error_code=error_code,
+                error_message=error_message,
+                trace_id=trace_id,
+            )
 
     if dedup.is_duplicate(message_id):
         stats.record("DUPLICATE")

--- a/src/collector/app/uid_mapping.py
+++ b/src/collector/app/uid_mapping.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from threading import Lock
+from typing import Any
+
+
+def _epoch_of(value: Any) -> str:
+    if value in (None, ""):
+        return "default"
+    return str(value)
+
+
+@dataclass
+class EpochMap:
+    node_uids: set[str] = field(default_factory=set)
+    link_uids: set[str] = field(default_factory=set)
+
+
+class UidMappingService:
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._epochs: dict[str, EpochMap] = {}
+        self._mapping_fail_counts: dict[str, int] = {}
+        self._alarm_total = 0
+        self._alarm_scope_uid = 0
+
+    def _get_epoch(self, epoch: str) -> EpochMap:
+        rec = self._epochs.get(epoch)
+        if rec is None:
+            rec = EpochMap()
+            self._epochs[epoch] = rec
+        return rec
+
+    def upsert_node(self, topology_epoch: Any, node_uid: str) -> None:
+        uid = str(node_uid or "").strip()
+        if not uid:
+            return
+        epoch = _epoch_of(topology_epoch)
+        with self._lock:
+            self._get_epoch(epoch).node_uids.add(uid)
+
+    def upsert_link(self, topology_epoch: Any, link_uid: str) -> None:
+        uid = str(link_uid or "").strip()
+        if not uid:
+            return
+        epoch = _epoch_of(topology_epoch)
+        with self._lock:
+            self._get_epoch(epoch).link_uids.add(uid)
+
+    def validate_alarm(self, payload: dict[str, Any]) -> tuple[str, str] | None:
+        scope_type = str(payload.get("scope_type") or "").strip().lower()
+        scope_uid = str(payload.get("scope_uid") or "").strip()
+        epoch = _epoch_of(payload.get("topology_epoch"))
+        with self._lock:
+            self._alarm_total += 1
+            if scope_uid:
+                self._alarm_scope_uid += 1
+            rec = self._epochs.get(epoch)
+            if rec is None:
+                self._mapping_fail_counts["EPOCH_MAPPING_NOT_FOUND"] = (
+                    self._mapping_fail_counts.get("EPOCH_MAPPING_NOT_FOUND", 0) + 1
+                )
+                return ("EPOCH_MAPPING_NOT_FOUND", "当前 topology_epoch 无可用映射")
+            if scope_type == "node":
+                if not scope_uid or scope_uid not in rec.node_uids:
+                    self._mapping_fail_counts["UNKNOWN_NODE_UID"] = self._mapping_fail_counts.get("UNKNOWN_NODE_UID", 0) + 1
+                    return ("UNKNOWN_NODE_UID", f"未找到 node_uid 映射: {scope_uid or '<empty>'}")
+            if scope_type == "link":
+                if not scope_uid or scope_uid not in rec.link_uids:
+                    self._mapping_fail_counts["UNKNOWN_LINK_UID"] = self._mapping_fail_counts.get("UNKNOWN_LINK_UID", 0) + 1
+                    return ("UNKNOWN_LINK_UID", f"未找到 link_uid 映射: {scope_uid or '<empty>'}")
+        return None
+
+    def stats(self) -> dict[str, Any]:
+        with self._lock:
+            total = self._alarm_total
+            covered = self._alarm_scope_uid
+            coverage = round(covered / total, 4) if total else 1.0
+            return {
+                "epoch_count": len(self._epochs),
+                "mapping_fail_counts": dict(self._mapping_fail_counts),
+                "alarm_total": total,
+                "alarm_scope_uid_total": covered,
+                "alarm_scope_uid_coverage": coverage,
+            }


### PR DESCRIPTION
## 背景与目标
实现 I-032：标准化与映射服务（UID Mapping Service），将 UID 映射校验从分散逻辑收敛为独立能力，并提供可观测接口。

## 变更内容
- 新增 `UidMappingService`（按 `topology_epoch` 维护 node/link UID 映射）
- ingest 流程改为使用映射服务做 alarm 映射校验
- 新增映射统计接口：`GET /api/v1/monitor/mapping/stats`
- `/metrics` 增加 `uid_mapping` 统计（覆盖率、失败计数等）
- README 补充 I-032 映射规则与错误码说明

## 验证方式与结果
- 未建立映射先上报 alarm：返回 `422 + EPOCH_MAPPING_NOT_FOUND`
- 先上报 `node_metric` 建立映射再上报 alarm：成功返回 `200`
- `mapping/stats` 可见：`epoch_count`、`mapping_fail_counts`、`alarm_scope_uid_coverage`

## 风险与回滚方案
- 风险：映射校验变严格后，历史脏数据可能被拒绝
- 回滚：回退本分支，恢复旧校验路径

## 影响范围
- collector 入站映射校验链路
- 前端告警定位数据质量
- /metrics 与映射观测接口
