### PR TITLE
[I-033] Timescale 查询网关（Series API）

### DIFF
--- a/src/collector/README.md
+++ b/src/collector/README.md
@@ -15,6 +15,9 @@
   - 支持条件请求：`If-None-Match` 命中后返回 `304`
 - `GET /api/v1/ops/failed-events`：查看失败事件审计与状态
 - `POST /api/v1/ops/failed-events/replay`：手动重放失败事件
+- `GET /api/v1/monitor/series`：Timescale 查询网关（统一时序查询）
+  - 必填参数：`event_type`、`metric`、`entity_id`
+  - 可选参数：`topology_epoch`、`limit`、`start`、`end`、`bucket_sec`、`agg(avg|max|min)`
 - `POST /api/v1/ingest/{kind}`：上报入口
   - kind 取值：`node_metric`、`node-metric`、`link_metric`、`link-metric`、`flow`、`alarm`
 - Header：
@@ -56,3 +59,12 @@
 ## Timescale 写入
 - 入站事件在发布 NATS 成功后会尝试写入 Timescale（四类表）
 - 写库失败不会阻断主请求，会记录 `DB_WRITE_FAILED` 并进入 failed-events 审计
+
+## Timescale 查询网关（I-033）
+- 查询结果统一返回：
+  - `source=timescaledb`
+  - `query`（入参回显）
+  - `range`（返回数据时间范围）
+  - `points` + `count`
+- 支持按时间窗口查询（`start/end`）
+- 支持按桶聚合降采样（`bucket_sec + agg`）

--- a/src/collector/app/main.py
+++ b/src/collector/app/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import deque
+from datetime import datetime
 from typing import Optional
 
 from fastapi import FastAPI, HTTPException, Request, Response
@@ -102,10 +103,18 @@ def create_app() -> FastAPI:
         entity_id: str,
         topology_epoch: Optional[str] = None,
         limit: int = 120,
+        start: Optional[str] = None,
+        end: Optional[str] = None,
+        bucket_sec: Optional[int] = None,
+        agg: str = "avg",
     ) -> dict[str, object]:
         ts_writer = app.state.ts_writer
         if ts_writer is None or not ts_writer.is_ready():
             raise HTTPException(status_code=503, detail="timescale db not ready")
+        start_dt = _parse_iso_datetime(start, field="start")
+        end_dt = _parse_iso_datetime(end, field="end")
+        if start_dt and end_dt and start_dt > end_dt:
+            raise HTTPException(status_code=422, detail="start 不能晚于 end")
         try:
             points = ts_writer.read_metric_series(
                 event_type=event_type,
@@ -113,9 +122,15 @@ def create_app() -> FastAPI:
                 entity_id=entity_id,
                 limit=limit,
                 topology_epoch=topology_epoch,
+                start=start_dt,
+                end=end_dt,
+                bucket_sec=bucket_sec,
+                agg=agg,
             )
         except Exception as exc:  # noqa: BLE001
             raise HTTPException(status_code=422, detail=str(exc)) from exc
+        ts_start = points[0]["ts"] if points else None
+        ts_end = points[-1]["ts"] if points else None
         return {
             "status": "ok",
             "source": "timescaledb",
@@ -123,8 +138,16 @@ def create_app() -> FastAPI:
             "metric": metric,
             "entity_id": entity_id,
             "topology_epoch": topology_epoch,
+            "query": {
+                "limit": limit,
+                "start": start,
+                "end": end,
+                "bucket_sec": bucket_sec,
+                "agg": agg,
+            },
             "points": points,
             "count": len(points),
+            "range": {"start": ts_start, "end": ts_end},
         }
 
     @app.get("/api/v1/analysis/forecast/lstm")
@@ -233,3 +256,13 @@ def _forecast_wma(values: list[float], window: int, steps: int) -> list[float]:
 
 
 app = create_app()
+
+
+def _parse_iso_datetime(raw: Optional[str], *, field: str) -> datetime | None:
+    if raw in (None, ""):
+        return None
+    text = str(raw).strip()
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=f"{field} 需为 ISO-8601 时间格式") from exc

--- a/src/collector/app/storage.py
+++ b/src/collector/app/storage.py
@@ -179,23 +179,45 @@ class TimescaleWriter:
         entity_id: str,
         limit: int = 120,
         topology_epoch: str | None = None,
+        start: datetime | None = None,
+        end: datetime | None = None,
+        bucket_sec: int | None = None,
+        agg: str = "avg",
     ) -> list[dict[str, Any]]:
         if not self.is_ready():
             raise TimescaleWriteError("timescale connection is not ready")
 
         table, id_column, metric_column = self._resolve_series_mapping(event_type=event_type, metric=metric)
         safe_limit = max(1, min(int(limit), 2000))
+        safe_bucket = None if bucket_sec is None else max(1, min(int(bucket_sec), 3600 * 24))
+        agg_sql = self._resolve_agg(agg)
 
-        sql = f"""
-        SELECT ts, {metric_column}
-        FROM {self.schema}.{table}
-        WHERE {id_column} = %s
-        """
+        if safe_bucket is None:
+            sql = f"""
+            SELECT ts, {metric_column}
+            FROM {self.schema}.{table}
+            WHERE {id_column} = %s
+            """
+        else:
+            sql = f"""
+            SELECT time_bucket(INTERVAL '{safe_bucket} second', ts) AS bucket_ts, {agg_sql}({metric_column}) AS metric_value
+            FROM {self.schema}.{table}
+            WHERE {id_column} = %s
+            """
         params: list[Any] = [entity_id]
         if topology_epoch not in (None, ""):
             sql += " AND topology_epoch = %s"
             params.append(topology_epoch)
-        sql += " ORDER BY ts DESC LIMIT %s"
+        if start is not None:
+            sql += " AND ts >= %s"
+            params.append(start)
+        if end is not None:
+            sql += " AND ts <= %s"
+            params.append(end)
+        if safe_bucket is None:
+            sql += " ORDER BY ts DESC LIMIT %s"
+        else:
+            sql += " GROUP BY bucket_ts ORDER BY bucket_ts DESC LIMIT %s"
         params.append(safe_limit)
 
         rows = self._query(sql, tuple(params))
@@ -236,3 +258,10 @@ class TimescaleWriter:
                 return list(cur.fetchall())
         except Exception as exc:  # noqa: BLE001
             raise TimescaleWriteError(str(exc)) from exc
+
+    @staticmethod
+    def _resolve_agg(agg: str) -> str:
+        val = str(agg or "avg").strip().lower()
+        if val in {"avg", "max", "min"}:
+            return val
+        raise TimescaleWriteError(f"unsupported agg={agg}, expected avg|max|min")


### PR DESCRIPTION
## 背景与目标
实现 I-033：Timescale 查询网关（Series API），统一对外时序查询能力并增强窗口与聚合查询。

## 变更内容
- `GET /api/v1/monitor/series` 新增参数：
  - `start` / `end`（ISO-8601 时间窗口）
  - `bucket_sec` + `agg(avg|max|min)`（按桶聚合降采样）
- 查询返回新增：
  - `query`（入参回显）
  - `range`（返回数据时间范围）
- storage 查询层支持按窗口过滤和聚合 SQL
- README 补充 Timescale 查询网关能力说明

## 验证方式与结果
- 基础查询：`event_type=node_metric&metric=cpu_ratio` 返回 points/count/source
- 聚合查询：`bucket_sec=60&agg=avg` 返回分钟级聚合点
- 错参验证：`start=bad-time` 返回 `422` 与明确错误信息

## 风险与回滚方案
- 风险：聚合参数使用不当导致查询性能波动
- 回滚：回退本分支，恢复基础查询模式

## 影响范围
- collector 的 series 查询接口
- Timescale 查询语句与结果结构
