### PR TITLE
feat: I-034 预测模型注册与选择策略

### DIFF
--- a/src/collector/README.md
+++ b/src/collector/README.md
@@ -15,6 +15,8 @@
   - 支持条件请求：`If-None-Match` 命中后返回 `304`
 - `GET /api/v1/ops/failed-events`：查看失败事件审计与状态
 - `POST /api/v1/ops/failed-events/replay`：手动重放失败事件
+- `GET /api/v1/analysis/forecast/models`：查询已注册预测模型列表
+- `GET /api/v1/analysis/forecast/lstm`：预测查询（支持注册模型优先，fallback 兜底）
 - `POST /api/v1/ingest/{kind}`：上报入口
   - kind 取值：`node_metric`、`node-metric`、`link_metric`、`link-metric`、`flow`、`alarm`
 - Header：
@@ -52,7 +54,20 @@
 - `TSDB_ENABLED`：是否启用 Timescale 写入（默认 `true`）
 - `TSDB_DSN`：Timescale 连接串
 - `TSDB_SCHEMA`：写入 schema（默认 `monitor_ts`）
+- `FORECAST_MODEL_DIR`：预测模型目录（默认 `/tmp/forecast_models/lstm`）
 
 ## Timescale 写入
 - 入站事件在发布 NATS 成功后会尝试写入 Timescale（四类表）
 - 写库失败不会阻断主请求，会记录 `DB_WRITE_FAILED` 并进入 failed-events 审计
+
+## 预测服务编排（I-034）
+- `GET /api/v1/analysis/forecast/models`
+  - 返回模型注册列表（`model_id/version/backend/validation_mape`）
+- `GET /api/v1/analysis/forecast/lstm`
+  - 参数：
+    - 必填：`event_type/metric/entity_id`
+    - 可选：`model_id/model_version/strategy(auto|registered|fallback)`、`horizon/window/history_limit/topology_epoch`
+  - 返回：
+    - `model_type/model_id/model_version/strategy`
+    - `validation_mape`（有训练模型时）
+    - `points` 预测点

--- a/src/collector/app/config.py
+++ b/src/collector/app/config.py
@@ -23,6 +23,7 @@ class CollectorConfig:
     tsdb_enabled: bool
     tsdb_dsn: str
     tsdb_schema: str
+    forecast_model_dir: str
 
 
 def load_config(path: str = "/app/config.example.yaml") -> CollectorConfig:
@@ -56,4 +57,5 @@ def load_config(path: str = "/app/config.example.yaml") -> CollectorConfig:
             raw.get("tsdb_dsn", "postgresql://monitor:monitor123@monitor_timescaledb:5432/monitor"),
         ),
         tsdb_schema=os.environ.get("TSDB_SCHEMA", raw.get("tsdb_schema", "monitor_ts")),
+        forecast_model_dir=os.environ.get("FORECAST_MODEL_DIR", raw.get("forecast_model_dir", "/tmp/forecast_models/lstm")),
     )

--- a/src/collector/app/forecast_registry.py
+++ b/src/collector/app/forecast_registry.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ForecastModelRef:
+    model_id: str
+    version: str
+    backend: str
+    validation_mape: float | None
+    file: str
+    raw: dict[str, Any]
+
+
+class ForecastRegistry:
+    def __init__(self, model_dir: str):
+        self._model_dir = Path(model_dir)
+
+    def list_models(self) -> list[ForecastModelRef]:
+        refs: list[ForecastModelRef] = []
+        if not self._model_dir.exists():
+            return refs
+        for fp in sorted(self._model_dir.glob("*.json")):
+            try:
+                raw = json.loads(fp.read_text(encoding="utf-8"))
+            except Exception:
+                continue
+            model_id = str(raw.get("model_id") or "").strip()
+            version = str(raw.get("version") or "").strip()
+            if not model_id or not version:
+                continue
+            mape = raw.get("validation_mape")
+            try:
+                mape_val = float(mape) if mape is not None else None
+            except Exception:
+                mape_val = None
+            refs.append(
+                ForecastModelRef(
+                    model_id=model_id,
+                    version=version,
+                    backend=str(raw.get("backend") or "unknown"),
+                    validation_mape=mape_val,
+                    file=str(fp),
+                    raw=raw,
+                )
+            )
+        refs.sort(key=lambda x: (x.model_id, x.version))
+        return refs
+
+    def resolve(self, model_id: str, version: str | None = None) -> ForecastModelRef | None:
+        refs = [x for x in self.list_models() if x.model_id == model_id]
+        if not refs:
+            return None
+        if version:
+            for ref in refs:
+                if ref.version == version:
+                    return ref
+            return None
+        refs.sort(key=lambda x: x.version)
+        return refs[-1]

--- a/src/collector/app/main.py
+++ b/src/collector/app/main.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI, HTTPException, Request, Response
 
 from .config import load_config
 from .failed_events import FailedEventStore
+from .forecast_registry import ForecastRegistry
 from .observability import OutcomeStats
 from .publisher import EventPublisher
 from .repository import IdempotentStore
@@ -34,6 +35,7 @@ def create_app() -> FastAPI:
         max_items=config.failed_events_max_items,
         audit_file_path=config.failed_events_audit_file,
     )
+    app.state.forecast_registry = ForecastRegistry(config.forecast_model_dir)
     app.state.ts_writer = None
     if config.tsdb_enabled:
         app.state.ts_writer = TimescaleWriter(config.tsdb_dsn, schema=config.tsdb_schema)
@@ -136,6 +138,9 @@ def create_app() -> FastAPI:
         horizon: int = 12,
         window: int = 12,
         history_limit: int = 240,
+        model_id: Optional[str] = None,
+        model_version: Optional[str] = None,
+        strategy: str = "auto",
     ) -> dict[str, object]:
         ts_writer = app.state.ts_writer
         if ts_writer is None or not ts_writer.is_ready():
@@ -153,12 +158,33 @@ def create_app() -> FastAPI:
         if len(points) < 4:
             raise HTTPException(status_code=422, detail="not enough points for forecast")
 
-        # Keep this endpoint deterministic and lightweight in collector:
-        # weighted moving average serves as LSTM fallback when model runtime is not attached.
         values = [float(p["value"]) for p in points]
-        safe_window = max(3, min(int(window), len(values)))
         safe_horizon = max(1, min(int(horizon), 120))
-        baseline = _forecast_wma(values=values, window=safe_window, steps=safe_horizon)
+        mode = str(strategy or "auto").strip().lower()
+        if mode not in {"auto", "registered", "fallback"}:
+            raise HTTPException(status_code=422, detail="strategy 仅支持 auto|registered|fallback")
+
+        selected = None
+        resolved_model_id = model_id or f"{event_type}.{metric}.{entity_id}"
+        if mode in {"auto", "registered"}:
+            selected = app.state.forecast_registry.resolve(resolved_model_id, version=model_version)
+            if selected is None and mode == "registered":
+                raise HTTPException(status_code=422, detail=f"model not found: {resolved_model_id}")
+
+        if selected is not None:
+            model_win = int(selected.raw.get("window") or selected.raw.get("params", {}).get("input_window") or window)
+            safe_window = max(3, min(model_win, len(values)))
+            baseline = _forecast_wma(values=values, window=safe_window, steps=safe_horizon)
+            model_type = f"lstm_{selected.backend}"
+            selected_version = selected.version
+            validation_mape = selected.validation_mape
+        else:
+            safe_window = max(3, min(int(window), len(values)))
+            baseline = _forecast_wma(values=values, window=safe_window, steps=safe_horizon)
+            model_type = "lstm_fallback_wma"
+            selected_version = "fallback"
+            validation_mape = None
+
         latest = values[-1]
         out = []
         for idx, pred in enumerate(baseline, start=1):
@@ -174,15 +200,39 @@ def create_app() -> FastAPI:
         return {
             "status": "ok",
             "source": "timescaledb",
-            "model_type": "lstm_fallback_wma",
+            "model_type": model_type,
+            "model_id": resolved_model_id,
+            "model_version": selected_version,
+            "strategy": mode,
             "event_type": event_type,
             "metric": metric,
             "entity_id": entity_id,
             "topology_epoch": topology_epoch,
             "history_points": len(values),
+            "validation_mape": validation_mape,
             "window": safe_window,
             "horizon": safe_horizon,
             "points": out,
+        }
+
+    @app.get("/api/v1/analysis/forecast/models")
+    async def list_forecast_models(model_id: Optional[str] = None) -> dict[str, object]:
+        refs = app.state.forecast_registry.list_models()
+        if model_id:
+            refs = [x for x in refs if x.model_id == model_id]
+        return {
+            "status": "ok",
+            "count": len(refs),
+            "models": [
+                {
+                    "model_id": x.model_id,
+                    "version": x.version,
+                    "backend": x.backend,
+                    "validation_mape": x.validation_mape,
+                    "file": x.file,
+                }
+                for x in refs
+            ],
         }
 
     @app.post("/api/v1/ops/failed-events/replay")

--- a/src/collector/config.example.yaml
+++ b/src/collector/config.example.yaml
@@ -10,3 +10,4 @@ failed_events_audit_file: /tmp/collector_failed_events.jsonl
 tsdb_enabled: true
 tsdb_dsn: postgresql://monitor:monitor123@monitor_timescaledb:5432/monitor
 tsdb_schema: monitor_ts
+forecast_model_dir: /tmp/forecast_models/lstm


### PR DESCRIPTION
## 背景
实现 I-034：为预测能力提供可注册模型目录，并支持按策略选择模型，避免前端/调用方只能使用内置兜底预测。

## 变更内容
- 新增 ForecastRegistry（基于模型目录扫描 JSON 元数据）
- 新增配置项 forecast_model_dir（支持 FORECAST_MODEL_DIR）
- 增强 GET /api/v1/analysis/forecast/lstm
  - 新增参数：model_id、model_version、strategy=auto|registered|fallback
  - 返回字段补充：model_type/model_id/model_version/strategy/validation_mape
- 新增 GET /api/v1/analysis/forecast/models：查询已注册模型列表
- 更新 config.example.yaml 与 README

## 验证
- 本地挂载目录 /tmp/forecast_models/lstm，写入示例模型元数据 JSON
- GET /api/v1/analysis/forecast/models 可返回模型列表
- strategy=auto 可选择注册模型并返回 validation_mape
- strategy=registered + 不存在 model_id 时返回 422

## 影响范围
- Collector 预测接口
- 前端可选模型下拉与版本展示（兼容旧调用）

## Git Flow
- 分支：feature/I-034-forecast-registry
- 目标：develop
