### PR TITLE
feat: I-035 故障追踪服务上线（Spread + Task Impact API）

### DIFF
--- a/src/collector/README.md
+++ b/src/collector/README.md
@@ -71,3 +71,21 @@
     - `model_type/model_id/model_version/strategy`
     - `validation_mape`（有训练模型时）
     - `points` 预测点
+
+## 故障追踪服务（I-035）
+- `POST /api/v1/fault/spread`
+- `POST /api/v1/fault/spread/analyze`（兼容路径）
+  - 必填：`alarm_nodes(list)`、`links(list)`
+  - 可选：`mode(single_point|cascade)`、`max_depth`、`cascade_threshold`
+  - 返回：`impacted_nodes/impacted_links/subgraph/paths`
+- `POST /api/v1/fault/task-impact`
+- `POST /api/v1/fault/task-impact/evaluate`（兼容路径）
+  - 必填：`tasks(list)`、`link_metrics(dict)`
+  - 可选：`fault_spread`、`rtt_warn_ms`、`loss_warn_rate`
+  - 返回：`tasks/work_orders/impacted_link_count`
+
+## 故障 API 自测
+- 先安装依赖（Python 3.10）：
+  - `uv venv --python /usr/bin/python3.10 .venv310 && source .venv310/bin/activate && uv pip install -r requirements.txt httpx`
+- 运行：
+  - `python scripts/test_fault_api.py`

--- a/src/collector/app/fault_spread.py
+++ b/src/collector/app/fault_spread.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from typing import Any
+
+
+def _build_graph(links: list[dict[str, Any]]) -> dict[str, set[str]]:
+    graph: dict[str, set[str]] = defaultdict(set)
+    for link in links:
+        src = str(link.get("src") or link.get("src_node") or "").strip()
+        dst = str(link.get("dst") or link.get("dst_node") or "").strip()
+        if not src or not dst:
+            continue
+        graph[src].add(dst)
+        graph[dst].add(src)
+    return graph
+
+
+def _bfs_layers(graph: dict[str, set[str]], seeds: list[str], max_depth: int) -> dict[str, int]:
+    depth_map: dict[str, int] = {}
+    queue: deque[tuple[str, int]] = deque()
+    for seed in seeds:
+        if seed in graph:
+            depth_map[seed] = 0
+            queue.append((seed, 0))
+    while queue:
+        node, depth = queue.popleft()
+        if depth >= max_depth:
+            continue
+        for nxt in graph.get(node, set()):
+            if nxt in depth_map:
+                continue
+            depth_map[nxt] = depth + 1
+            queue.append((nxt, depth + 1))
+    return depth_map
+
+
+def _norm_link_uid(src: str, dst: str) -> str:
+    a = str(src or "").strip()
+    b = str(dst or "").strip()
+    if not a or not b:
+        return ""
+    return "<->".join(sorted([a, b]))
+
+
+def _impacted_edges(graph: dict[str, set[str]], impacted_nodes: set[str]) -> list[dict[str, str]]:
+    out: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for src in impacted_nodes:
+        for dst in graph.get(src, set()):
+            if dst not in impacted_nodes:
+                continue
+            key = tuple(sorted([src, dst]))
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append({"src": key[0], "dst": key[1], "uid": _norm_link_uid(key[0], key[1])})
+    return out
+
+
+@dataclass
+class AnalyzeRequest:
+    alarm_nodes: list[str]
+    links: list[dict[str, Any]]
+    max_depth: int = 3
+    mode: str = "single_point"
+    cascade_threshold: float = 0.6
+
+
+class SpreadAnalyzer:
+    def analyze(self, req: AnalyzeRequest) -> dict[str, Any]:
+        graph = _build_graph(req.links)
+        seeds = [str(x) for x in req.alarm_nodes if str(x).strip()]
+        if not seeds:
+            return {
+                "mode": "single_point",
+                "seeds": [],
+                "core_nodes": [],
+                "boundary_nodes": [],
+                "unaffected_nodes": sorted(graph.keys()),
+                "impacted_nodes": [],
+                "impacted_links": [],
+                "subgraph": {"nodes": [], "edges": []},
+                "paths": [],
+                "fallback": True,
+            }
+
+        depth_map = _bfs_layers(graph, seeds, max_depth=req.max_depth)
+        impacted_nodes = set(depth_map.keys())
+        if req.mode == "cascade":
+            extended = set(impacted_nodes)
+            for link in req.links:
+                src = str(link.get("src") or link.get("src_node") or "")
+                dst = str(link.get("dst") or link.get("dst_node") or "")
+                health = float(link.get("health", 1.0))
+                if health < req.cascade_threshold and (src in impacted_nodes or dst in impacted_nodes):
+                    extended.add(src)
+                    extended.add(dst)
+            impacted_nodes = extended
+
+        core_nodes = {n for n, depth in depth_map.items() if depth <= 1}
+        boundary_nodes = {n for n, depth in depth_map.items() if depth == req.max_depth}
+        all_nodes = set(graph.keys())
+        edges = _impacted_edges(graph, impacted_nodes)
+        paths = [{"node": node, "depth": depth_map.get(node, req.max_depth + 1)} for node in sorted(impacted_nodes)]
+        return {
+            "mode": req.mode,
+            "seeds": seeds,
+            "core_nodes": sorted(core_nodes),
+            "boundary_nodes": sorted(boundary_nodes),
+            "unaffected_nodes": sorted(all_nodes - impacted_nodes),
+            "impacted_nodes": sorted(impacted_nodes),
+            "impacted_links": [str(edge.get("uid")) for edge in edges if edge.get("uid")],
+            "subgraph": {"nodes": sorted(impacted_nodes), "edges": edges},
+            "paths": paths,
+            "fallback": False,
+        }

--- a/src/collector/app/fault_task_impact.py
+++ b/src/collector/app/fault_task_impact.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _norm_link_uid(src: str, dst: str) -> str:
+    a = str(src or "").strip()
+    b = str(dst or "").strip()
+    if not a or not b:
+        return ""
+    return "<->".join(sorted([a, b]))
+
+
+def _task_links(task: dict[str, Any]) -> list[str]:
+    links = task.get("links")
+    if isinstance(links, list):
+        return [str(x) for x in links if str(x).strip()]
+    paths = task.get("paths")
+    if not isinstance(paths, list):
+        return []
+    merged: list[str] = []
+    for path in paths:
+        if not isinstance(path, list) or len(path) < 2:
+            continue
+        for idx in range(len(path) - 1):
+            uid = _norm_link_uid(str(path[idx]), str(path[idx + 1]))
+            if uid:
+                merged.append(uid)
+    seen: set[str] = set()
+    out: list[str] = []
+    for uid in merged:
+        if uid in seen:
+            continue
+        seen.add(uid)
+        out.append(uid)
+    return out
+
+
+def _impacted_links_from_spread(fault_spread: dict[str, Any] | None) -> set[str]:
+    subgraph = (fault_spread or {}).get("subgraph", {})
+    edges = subgraph.get("edges", [])
+    out: set[str] = set()
+    if not isinstance(edges, list):
+        return out
+    for edge in edges:
+        if not isinstance(edge, dict):
+            continue
+        uid = _norm_link_uid(str(edge.get("src") or ""), str(edge.get("dst") or ""))
+        if uid:
+            out.add(uid)
+    return out
+
+
+@dataclass
+class TaskImpactRequest:
+    tasks: list[dict[str, Any]]
+    link_metrics: dict[str, dict[str, Any]]
+    fault_spread: dict[str, Any] | None = None
+    rtt_warn_ms: float = 180.0
+    loss_warn_rate: float = 0.03
+
+
+class TaskImpactService:
+    def evaluate(self, req: TaskImpactRequest) -> dict[str, Any]:
+        impacted_links = _impacted_links_from_spread(req.fault_spread)
+        task_results: list[dict[str, Any]] = []
+        work_orders: list[dict[str, Any]] = []
+        for task in req.tasks:
+            result = self._evaluate_task(task, req.link_metrics, impacted_links, req.rtt_warn_ms, req.loss_warn_rate)
+            task_results.append(result)
+            if result["status"] != "normal":
+                work_orders.append(
+                    {
+                        "work_order_id": f"wo-{result['task_id'] or 'unknown'}",
+                        "task_id": result["task_id"],
+                        "status": "open",
+                        "priority_score": result["priority_score"],
+                        "suggestion": result["suggestion"],
+                        "created_at": _now(),
+                    }
+                )
+        task_results.sort(key=lambda item: (-float(item.get("priority_score", 0.0)), str(item.get("task_id", ""))))
+        work_orders.sort(key=lambda item: -float(item.get("priority_score", 0.0)))
+        return {
+            "evaluated_at": _now(),
+            "impacted_link_count": len(impacted_links),
+            "tasks": task_results,
+            "work_orders": work_orders,
+        }
+
+    def _evaluate_task(
+        self,
+        task: dict[str, Any],
+        link_metrics: dict[str, dict[str, Any]],
+        impacted_links: set[str],
+        rtt_warn_ms: float,
+        loss_warn_rate: float,
+    ) -> dict[str, Any]:
+        task_id = str(task.get("task_id") or "")
+        links = _task_links(task)
+        total_links = len(links)
+        impacted_count = 0
+        down_count = 0
+        latency_abnormal_count = 0
+        hit_links: list[str] = []
+
+        for uid in links:
+            metrics = link_metrics.get(uid, {})
+            if uid in impacted_links:
+                impacted_count += 1
+                hit_links.append(uid)
+            state = str(metrics.get("state") or "").upper()
+            if state == "DOWN":
+                down_count += 1
+            try:
+                rtt_ms = float(metrics.get("rtt_ms", 0.0))
+            except (TypeError, ValueError):
+                rtt_ms = 0.0
+            try:
+                loss_rate = float(metrics.get("loss_rate", 0.0))
+            except (TypeError, ValueError):
+                loss_rate = 0.0
+            if rtt_ms >= rtt_warn_ms or loss_rate >= loss_warn_rate:
+                latency_abnormal_count += 1
+
+        impacted_ratio = (impacted_count / total_links) if total_links > 0 else 0.0
+        down_ratio = (down_count / total_links) if total_links > 0 else 0.0
+        if total_links == 0:
+            status = "normal"
+        elif down_ratio >= 0.5 or impacted_ratio >= 0.8:
+            status = "disconnected"
+        elif impacted_count > 0:
+            status = "degraded"
+        elif latency_abnormal_count > 0:
+            status = "latency_anomaly"
+        else:
+            status = "normal"
+
+        criticality = float(task.get("criticality", 0.5))
+        status_weight = {"normal": 0.0, "latency_anomaly": 0.4, "degraded": 0.7, "disconnected": 1.0}[status]
+        priority_score = round(100 * (0.5 * criticality + 0.35 * impacted_ratio + 0.15 * status_weight), 2)
+        suggestion = (
+            "优先恢复断链与主备切换"
+            if status == "disconnected"
+            else "提升链路质量并限流保护"
+            if status == "degraded"
+            else "检查时延/丢包并回退高风险路径"
+            if status == "latency_anomaly"
+            else "维持观测"
+        )
+        return {
+            "task_id": task_id,
+            "name": task.get("name"),
+            "status": status,
+            "priority_score": priority_score,
+            "impacted_links": hit_links,
+            "metrics": {
+                "total_links": total_links,
+                "impacted_links": impacted_count,
+                "down_links": down_count,
+                "latency_abnormal_links": latency_abnormal_count,
+                "impacted_ratio": round(impacted_ratio, 4),
+            },
+            "suggestion": suggestion,
+            "alert_item": {
+                "task_id": task_id,
+                "status": status,
+                "ackable": status != "disconnected",
+                "title": f"任务影响评估: {task.get('name') or task_id}",
+                "detail": f"impacted={impacted_count}/{total_links}, down={down_count}, latency_abnormal={latency_abnormal_count}",
+            },
+        }

--- a/src/collector/app/main.py
+++ b/src/collector/app/main.py
@@ -7,6 +7,8 @@ from fastapi import FastAPI, HTTPException, Request, Response
 
 from .config import load_config
 from .failed_events import FailedEventStore
+from .fault_spread import AnalyzeRequest, SpreadAnalyzer
+from .fault_task_impact import TaskImpactRequest, TaskImpactService
 from .forecast_registry import ForecastRegistry
 from .observability import OutcomeStats
 from .publisher import EventPublisher
@@ -36,6 +38,8 @@ def create_app() -> FastAPI:
         audit_file_path=config.failed_events_audit_file,
     )
     app.state.forecast_registry = ForecastRegistry(config.forecast_model_dir)
+    app.state.fault_spread = SpreadAnalyzer()
+    app.state.task_impact = TaskImpactService()
     app.state.ts_writer = None
     if config.tsdb_enabled:
         app.state.ts_writer = TimescaleWriter(config.tsdb_dsn, schema=config.tsdb_schema)
@@ -234,6 +238,43 @@ def create_app() -> FastAPI:
                 for x in refs
             ],
         }
+
+    @app.post("/api/v1/fault/spread")
+    @app.post("/api/v1/fault/spread/analyze")
+    async def fault_spread(payload: dict[str, object]) -> dict[str, object]:
+        alarm_nodes = payload.get("alarm_nodes")
+        links = payload.get("links")
+        if not isinstance(alarm_nodes, list) or not isinstance(links, list):
+            raise HTTPException(status_code=422, detail="alarm_nodes(list) 与 links(list) 为必填")
+        mode = str(payload.get("mode", "single_point"))
+        if mode not in {"single_point", "cascade"}:
+            raise HTTPException(status_code=422, detail="mode 仅支持 single_point|cascade")
+        req = AnalyzeRequest(
+            alarm_nodes=[str(x) for x in alarm_nodes],
+            links=[x for x in links if isinstance(x, dict)],
+            max_depth=max(1, min(int(payload.get("max_depth", 3)), 8)),
+            mode=mode,
+            cascade_threshold=float(payload.get("cascade_threshold", 0.6)),
+        )
+        result = app.state.fault_spread.analyze(req)
+        return {"status": "ok", "result": result}
+
+    @app.post("/api/v1/fault/task-impact")
+    @app.post("/api/v1/fault/task-impact/evaluate")
+    async def fault_task_impact(payload: dict[str, object]) -> dict[str, object]:
+        tasks = payload.get("tasks")
+        link_metrics = payload.get("link_metrics")
+        if not isinstance(tasks, list) or not isinstance(link_metrics, dict):
+            raise HTTPException(status_code=422, detail="tasks(list) 与 link_metrics(dict) 为必填")
+        req = TaskImpactRequest(
+            tasks=[x for x in tasks if isinstance(x, dict)],
+            link_metrics={str(k): v for k, v in link_metrics.items() if isinstance(v, dict)},
+            fault_spread=payload.get("fault_spread") if isinstance(payload.get("fault_spread"), dict) else None,
+            rtt_warn_ms=float(payload.get("rtt_warn_ms", 180.0)),
+            loss_warn_rate=float(payload.get("loss_warn_rate", 0.03)),
+        )
+        result = app.state.task_impact.evaluate(req)
+        return {"status": "ok", "result": result}
 
     @app.post("/api/v1/ops/failed-events/replay")
     async def replay_failed_events(limit: int = 50) -> dict[str, object]:

--- a/src/collector/scripts/test_fault_api.py
+++ b/src/collector/scripts/test_fault_api.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import asyncio
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+
+import httpx
+
+# Avoid startup dependencies (NATS/TSDB) during API-level tests.
+os.environ.setdefault("TSDB_ENABLED", "false")
+os.environ.setdefault("NATS_URL", "nats://127.0.0.1:4222")
+os.environ.setdefault("FORECAST_MODEL_DIR", "/tmp/forecast_models/lstm")
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.main import create_app
+
+
+SPREAD_PAYLOAD = {
+    "alarm_nodes": ["SAT-INCL-001"],
+    "links": [
+        {"src": "SAT-INCL-001", "dst": "SAT-INCL-011", "health": 0.40},
+        {"src": "SAT-INCL-011", "dst": "GW-EDGE-001", "health": 0.55},
+        {"src": "GW-EDGE-001", "dst": "DC-CORE-001", "health": 0.91},
+    ],
+    "mode": "cascade",
+    "max_depth": 3,
+    "cascade_threshold": 0.6,
+}
+
+
+async def main() -> None:
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://collector") as client:
+        invalid = await client.post("/api/v1/fault/spread", json={"foo": "bar"})
+        assert invalid.status_code == 422, f"unexpected invalid status: {invalid.status_code}"
+
+        spread_resp = await client.post("/api/v1/fault/spread", json=SPREAD_PAYLOAD)
+        assert spread_resp.status_code == 200, spread_resp.text
+        spread_result = spread_resp.json()["result"]
+        assert isinstance(spread_result.get("impacted_nodes"), list)
+        assert isinstance(spread_result.get("impacted_links"), list)
+
+        task_payload = {
+            "tasks": [
+                {
+                    "task_id": "task-recon-001",
+                    "name": "态势侦察",
+                    "criticality": 0.9,
+                    "links": ["SAT-INCL-001<->SAT-INCL-011", "SAT-INCL-011<->GW-EDGE-001"],
+                },
+                {
+                    "task_id": "task-c2-001",
+                    "name": "指挥链路",
+                    "criticality": 0.7,
+                    "links": ["GW-EDGE-001<->DC-CORE-001"],
+                },
+            ],
+            "link_metrics": {
+                "SAT-INCL-001<->SAT-INCL-011": {"state": "DOWN", "rtt_ms": 350, "loss_rate": 0.2},
+                "SAT-INCL-011<->GW-EDGE-001": {"state": "UP", "rtt_ms": 210, "loss_rate": 0.04},
+                "GW-EDGE-001<->DC-CORE-001": {"state": "UP", "rtt_ms": 80, "loss_rate": 0.002},
+            },
+            "fault_spread": spread_result,
+            "rtt_warn_ms": 180,
+            "loss_warn_rate": 0.03,
+        }
+        task_resp = await client.post("/api/v1/fault/task-impact", json=task_payload)
+        assert task_resp.status_code == 200, task_resp.text
+        task_result = task_resp.json()["result"]
+        assert len(task_result.get("tasks", [])) == 2
+
+        samples: list[float] = []
+        for _ in range(200):
+            t0 = time.perf_counter()
+            r = await client.post("/api/v1/fault/spread", json=SPREAD_PAYLOAD)
+            dt = (time.perf_counter() - t0) * 1000.0
+            assert r.status_code == 200, r.text
+            samples.append(dt)
+
+    samples_sorted = sorted(samples)
+    p95 = samples_sorted[int(0.95 * (len(samples_sorted) - 1))]
+    avg = statistics.mean(samples)
+    print(f"fault_api_test_ok: avg_ms={avg:.3f}, p95_ms={p95:.3f}, n={len(samples)}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## 背景
实现 I-035：将故障传播与任务影响评估能力接入 collector 在线 API，供前端直接调用。

## 变更内容
- 新增 `src/collector/app/fault_spread.py`
  - 图构建 + BFS 扩散
  - 支持 `single_point|cascade`
  - 返回 `impacted_nodes/impacted_links/subgraph/paths`
- 新增 `src/collector/app/fault_task_impact.py`
  - 根据 `fault_spread + link_metrics + tasks` 评估任务状态
  - 输出 `tasks/work_orders/priority_score`
- 更新 `src/collector/app/main.py`
  - 新增路由：
    - `POST /api/v1/fault/spread`
    - `POST /api/v1/fault/spread/analyze`（兼容）
    - `POST /api/v1/fault/task-impact`
    - `POST /api/v1/fault/task-impact/evaluate`（兼容）
- 新增 `src/collector/scripts/test_fault_api.py`
  - API 级自测：异常参数 422、正常响应结构、基础性能统计
- 更新 `src/collector/README.md`：I-035 接口与自测说明

## 验证
- 本地 API 级测试（.venv310）
- 命令：`python scripts/test_fault_api.py`
- 结果：`fault_api_test_ok: avg_ms=0.556, p95_ms=0.599, n=200`

## DoD 对照
1. `/api/v1/fault/spread` 在线接口已提供
2. `/api/v1/fault/task-impact` 在线接口已提供
3. 响应包含影响节点/链路/任务与工单
4. 已覆盖异常响应与基础性能测试

## Git Flow
- 分支：`feature/I-035-fault-trace-api`
- 目标：`develop`
