### PR TITLE
feat: I-036 前端聚合 BFF（统一 API 前缀）

### DIFF
--- a/src/collector/README.md
+++ b/src/collector/README.md
@@ -89,3 +89,18 @@
   - `uv venv --python /usr/bin/python3.10 .venv310 && source .venv310/bin/activate && uv pip install -r requirements.txt httpx`
 - 运行：
   - `python scripts/test_fault_api.py`
+
+## 前端聚合 BFF（I-036）
+- 统一前缀：`/api/v1/bff/*`
+- 路由：
+  - `GET /api/v1/bff/snapshot`
+  - `GET /api/v1/bff/series`
+  - `GET /api/v1/bff/forecast/lstm`
+  - `POST /api/v1/bff/fault/spread`
+  - `POST /api/v1/bff/fault/task-impact`
+- 说明：
+  - BFF 为薄聚合层，当前复用已有业务实现与响应结构
+  - `snapshot` 保持 ETag/304 兼容
+
+## BFF 自测
+- `python scripts/test_bff_api.py`

--- a/src/collector/app/main.py
+++ b/src/collector/app/main.py
@@ -276,6 +276,64 @@ def create_app() -> FastAPI:
         result = app.state.task_impact.evaluate(req)
         return {"status": "ok", "result": result}
 
+    @app.get("/api/v1/bff/snapshot")
+    async def bff_snapshot(
+        request: Request,
+        response: Response,
+        topology_epoch: Optional[str] = None,
+    ) -> object:
+        return await monitor_snapshot(request=request, response=response, topology_epoch=topology_epoch)
+
+    @app.get("/api/v1/bff/series")
+    async def bff_series(
+        event_type: str,
+        metric: str,
+        entity_id: str,
+        topology_epoch: Optional[str] = None,
+        limit: int = 120,
+    ) -> dict[str, object]:
+        return await monitor_series(
+            event_type=event_type,
+            metric=metric,
+            entity_id=entity_id,
+            topology_epoch=topology_epoch,
+            limit=limit,
+        )
+
+    @app.get("/api/v1/bff/forecast/lstm")
+    async def bff_forecast_lstm(
+        event_type: str,
+        metric: str,
+        entity_id: str,
+        topology_epoch: Optional[str] = None,
+        horizon: int = 12,
+        window: int = 12,
+        history_limit: int = 240,
+        model_id: Optional[str] = None,
+        model_version: Optional[str] = None,
+        strategy: str = "auto",
+    ) -> dict[str, object]:
+        return await forecast_lstm(
+            event_type=event_type,
+            metric=metric,
+            entity_id=entity_id,
+            topology_epoch=topology_epoch,
+            horizon=horizon,
+            window=window,
+            history_limit=history_limit,
+            model_id=model_id,
+            model_version=model_version,
+            strategy=strategy,
+        )
+
+    @app.post("/api/v1/bff/fault/spread")
+    async def bff_fault_spread(payload: dict[str, object]) -> dict[str, object]:
+        return await fault_spread(payload=payload)
+
+    @app.post("/api/v1/bff/fault/task-impact")
+    async def bff_fault_task_impact(payload: dict[str, object]) -> dict[str, object]:
+        return await fault_task_impact(payload=payload)
+
     @app.post("/api/v1/ops/failed-events/replay")
     async def replay_failed_events(limit: int = 50) -> dict[str, object]:
         ids = app.state.failed_events.pending_event_ids(limit=limit)

--- a/src/collector/scripts/test_bff_api.py
+++ b/src/collector/scripts/test_bff_api.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+import httpx
+
+os.environ.setdefault("TSDB_ENABLED", "false")
+os.environ.setdefault("NATS_URL", "nats://127.0.0.1:4222")
+os.environ.setdefault("FORECAST_MODEL_DIR", "/tmp/forecast_models/lstm")
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.main import create_app
+
+
+class DummyTSWriter:
+    def is_ready(self) -> bool:
+        return True
+
+    def read_metric_series(self, event_type: str, metric: str, entity_id: str, limit: int, topology_epoch: str | None = None):
+        return [
+            {"ts": "2026-02-26T12:00:00Z", "value": 10.0},
+            {"ts": "2026-02-26T12:01:00Z", "value": 11.0},
+            {"ts": "2026-02-26T12:02:00Z", "value": 10.5},
+            {"ts": "2026-02-26T12:03:00Z", "value": 12.0},
+            {"ts": "2026-02-26T12:04:00Z", "value": 11.8},
+        ][: max(1, int(limit))]
+
+
+async def main() -> None:
+    app = create_app()
+    app.state.ts_writer = DummyTSWriter()
+
+    spread_payload = {
+        "alarm_nodes": ["SAT-INCL-001"],
+        "links": [
+            {"src": "SAT-INCL-001", "dst": "SAT-INCL-011", "health": 0.40},
+            {"src": "SAT-INCL-011", "dst": "GW-EDGE-001", "health": 0.55},
+        ],
+        "mode": "cascade",
+        "max_depth": 3,
+    }
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://collector") as client:
+        r1 = await client.get("/api/v1/bff/snapshot")
+        assert r1.status_code == 200, r1.text
+        etag = r1.headers.get("etag")
+        assert etag, "missing ETag"
+
+        r2 = await client.get("/api/v1/bff/snapshot", headers={"if-none-match": etag})
+        assert r2.status_code == 304, r2.text
+
+        rs = await client.get(
+            "/api/v1/bff/series",
+            params={
+                "event_type": "link_metric",
+                "metric": "rtt_ms",
+                "entity_id": "SAT-INCL-001<->SAT-INCL-011",
+                "limit": 5,
+            },
+        )
+        assert rs.status_code == 200, rs.text
+        assert isinstance(rs.json().get("points"), list)
+
+        rf = await client.get(
+            "/api/v1/bff/forecast/lstm",
+            params={
+                "event_type": "link_metric",
+                "metric": "rtt_ms",
+                "entity_id": "SAT-INCL-001<->SAT-INCL-011",
+                "strategy": "fallback",
+                "horizon": 3,
+                "window": 4,
+            },
+        )
+        assert rf.status_code == 200, rf.text
+        assert len(rf.json().get("points", [])) == 3
+
+        rspread = await client.post("/api/v1/bff/fault/spread", json=spread_payload)
+        assert rspread.status_code == 200, rspread.text
+        spread_result = rspread.json().get("result", {})
+
+        rimpact = await client.post(
+            "/api/v1/bff/fault/task-impact",
+            json={
+                "tasks": [
+                    {
+                        "task_id": "task-recon-001",
+                        "name": "态势侦察",
+                        "criticality": 0.9,
+                        "links": ["SAT-INCL-001<->SAT-INCL-011", "SAT-INCL-011<->GW-EDGE-001"],
+                    }
+                ],
+                "link_metrics": {
+                    "SAT-INCL-001<->SAT-INCL-011": {"state": "DOWN", "rtt_ms": 350, "loss_rate": 0.2},
+                    "SAT-INCL-011<->GW-EDGE-001": {"state": "UP", "rtt_ms": 210, "loss_rate": 0.04},
+                },
+                "fault_spread": spread_result,
+            },
+        )
+        assert rimpact.status_code == 200, rimpact.text
+        assert isinstance(rimpact.json().get("result", {}).get("tasks"), list)
+
+    print("bff_api_test_ok")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## 背景
实现 I-036：为前端提供单一 API 前缀，避免页面直接依赖多个后端路径，降低联调复杂度。

## 变更内容
- 在 `src/collector/app/main.py` 新增 BFF 路由（统一前缀 `/api/v1/bff/*`）
  - `GET /api/v1/bff/snapshot`
  - `GET /api/v1/bff/series`
  - `GET /api/v1/bff/forecast/lstm`
  - `POST /api/v1/bff/fault/spread`
  - `POST /api/v1/bff/fault/task-impact`
- BFF 采用薄聚合：复用既有业务接口逻辑与响应契约，降低回归风险
- `snapshot` BFF 路由保持 ETag/304 兼容
- 新增 `src/collector/scripts/test_bff_api.py`（API 级联调脚本）
- 更新 `src/collector/README.md`（BFF 路由与测试命令）

## 验证
- `python scripts/test_fault_api.py`
  - 结果：`fault_api_test_ok: avg_ms=0.545, p95_ms=0.582, n=200`
- `python scripts/test_bff_api.py`
  - 结果：`bff_api_test_ok`

## DoD 对照
1. 前端可统一使用 `/api/v1/bff/*` 前缀
2. snapshot/series/forecast/fault 契约与现有接口保持一致
3. snapshot 支持 ETag/304
4. 已提供可复用联调脚本

## Git Flow
- 分支：`feature/I-036-monitor-bff`
- 目标：`develop`
