### PR TITLE
feat: I-037 全链路可观测与 SLO 汇总

### DIFF
--- a/src/collector/README.md
+++ b/src/collector/README.md
@@ -104,3 +104,11 @@
 
 ## BFF 自测
 - `python scripts/test_bff_api.py`
+
+## 可观测与 SLO（I-037）
+- `GET /api/v1/ops/slo`
+  - 汇总维度：`ingest/db/query/forecast/fault`
+  - 输出：可用性、错误率、P95 延迟、SLO 判定
+
+## SLO 自测
+- `python scripts/test_slo_api.py`

--- a/src/collector/app/main.py
+++ b/src/collector/app/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import deque
+import time
 from typing import Optional
 
 from fastapi import FastAPI, HTTPException, Request, Response
@@ -10,7 +11,7 @@ from .failed_events import FailedEventStore
 from .fault_spread import AnalyzeRequest, SpreadAnalyzer
 from .fault_task_impact import TaskImpactRequest, TaskImpactService
 from .forecast_registry import ForecastRegistry
-from .observability import OutcomeStats
+from .observability import ApiSLOTracker, OutcomeStats
 from .publisher import EventPublisher
 from .repository import IdempotentStore
 from .routes import router
@@ -32,6 +33,7 @@ def create_app() -> FastAPI:
     )
     app.state.idempotent = IdempotentStore(ttl_seconds=config.idempotency_ttl)
     app.state.stats = OutcomeStats()
+    app.state.slo = ApiSLOTracker()
     app.state.snapshot_store = MonitorSnapshotStore()
     app.state.failed_events = FailedEventStore(
         max_items=config.failed_events_max_items,
@@ -75,24 +77,31 @@ def create_app() -> FastAPI:
         response: Response,
         topology_epoch: Optional[str] = None,
     ) -> object:
-        payload = app.state.snapshot_store.snapshot(topology_epoch=topology_epoch)
-        monitor = payload.get("monitor", {})
-        etag = str(monitor.get("etag") or "")
-        last_modified = str(monitor.get("last_modified") or "")
+        start = time.perf_counter()
+        ok = False
+        try:
+            payload = app.state.snapshot_store.snapshot(topology_epoch=topology_epoch)
+            monitor = payload.get("monitor", {})
+            etag = str(monitor.get("etag") or "")
+            last_modified = str(monitor.get("last_modified") or "")
 
-        if etag:
-            response.headers["ETag"] = etag
-        if last_modified:
-            response.headers["Last-Modified"] = last_modified
-
-        if_none_match = request.headers.get("if-none-match")
-        if etag and if_none_match and if_none_match == etag:
-            headers = {"ETag": etag}
+            if etag:
+                response.headers["ETag"] = etag
             if last_modified:
-                headers["Last-Modified"] = last_modified
-            return Response(status_code=304, headers=headers)
+                response.headers["Last-Modified"] = last_modified
 
-        return payload
+            if_none_match = request.headers.get("if-none-match")
+            if etag and if_none_match and if_none_match == etag:
+                headers = {"ETag": etag}
+                if last_modified:
+                    headers["Last-Modified"] = last_modified
+                ok = True
+                return Response(status_code=304, headers=headers)
+
+            ok = True
+            return payload
+        finally:
+            app.state.slo.record("query.snapshot", ok=ok, latency_ms=(time.perf_counter() - start) * 1000.0)
 
     @app.get("/api/v1/ops/failed-events")
     async def failed_events(limit: int = 100, status: Optional[str] = None) -> dict[str, object]:
@@ -109,29 +118,35 @@ def create_app() -> FastAPI:
         topology_epoch: Optional[str] = None,
         limit: int = 120,
     ) -> dict[str, object]:
-        ts_writer = app.state.ts_writer
-        if ts_writer is None or not ts_writer.is_ready():
-            raise HTTPException(status_code=503, detail="timescale db not ready")
+        start = time.perf_counter()
+        ok = False
         try:
-            points = ts_writer.read_metric_series(
-                event_type=event_type,
-                metric=metric,
-                entity_id=entity_id,
-                limit=limit,
-                topology_epoch=topology_epoch,
-            )
-        except Exception as exc:  # noqa: BLE001
-            raise HTTPException(status_code=422, detail=str(exc)) from exc
-        return {
-            "status": "ok",
-            "source": "timescaledb",
-            "event_type": event_type,
-            "metric": metric,
-            "entity_id": entity_id,
-            "topology_epoch": topology_epoch,
-            "points": points,
-            "count": len(points),
-        }
+            ts_writer = app.state.ts_writer
+            if ts_writer is None or not ts_writer.is_ready():
+                raise HTTPException(status_code=503, detail="timescale db not ready")
+            try:
+                points = ts_writer.read_metric_series(
+                    event_type=event_type,
+                    metric=metric,
+                    entity_id=entity_id,
+                    limit=limit,
+                    topology_epoch=topology_epoch,
+                )
+            except Exception as exc:  # noqa: BLE001
+                raise HTTPException(status_code=422, detail=str(exc)) from exc
+            ok = True
+            return {
+                "status": "ok",
+                "source": "timescaledb",
+                "event_type": event_type,
+                "metric": metric,
+                "entity_id": entity_id,
+                "topology_epoch": topology_epoch,
+                "points": points,
+                "count": len(points),
+            }
+        finally:
+            app.state.slo.record("query.series", ok=ok, latency_ms=(time.perf_counter() - start) * 1000.0)
 
     @app.get("/api/v1/analysis/forecast/lstm")
     async def forecast_lstm(
@@ -146,78 +161,86 @@ def create_app() -> FastAPI:
         model_version: Optional[str] = None,
         strategy: str = "auto",
     ) -> dict[str, object]:
-        ts_writer = app.state.ts_writer
-        if ts_writer is None or not ts_writer.is_ready():
-            raise HTTPException(status_code=503, detail="timescale db not ready")
+        start = time.perf_counter()
+        ok = False
         try:
-            points = ts_writer.read_metric_series(
-                event_type=event_type,
-                metric=metric,
-                entity_id=entity_id,
-                limit=history_limit,
-                topology_epoch=topology_epoch,
-            )
-        except Exception as exc:  # noqa: BLE001
-            raise HTTPException(status_code=422, detail=str(exc)) from exc
-        if len(points) < 4:
-            raise HTTPException(status_code=422, detail="not enough points for forecast")
+            ts_writer = app.state.ts_writer
+            if ts_writer is None or not ts_writer.is_ready():
+                raise HTTPException(status_code=503, detail="timescale db not ready")
+            try:
+                points = ts_writer.read_metric_series(
+                    event_type=event_type,
+                    metric=metric,
+                    entity_id=entity_id,
+                    limit=history_limit,
+                    topology_epoch=topology_epoch,
+                )
+            except Exception as exc:  # noqa: BLE001
+                raise HTTPException(status_code=422, detail=str(exc)) from exc
+            if len(points) < 4:
+                raise HTTPException(status_code=422, detail="not enough points for forecast")
 
-        values = [float(p["value"]) for p in points]
-        safe_horizon = max(1, min(int(horizon), 120))
-        mode = str(strategy or "auto").strip().lower()
-        if mode not in {"auto", "registered", "fallback"}:
-            raise HTTPException(status_code=422, detail="strategy 仅支持 auto|registered|fallback")
+            values = [float(p["value"]) for p in points]
+            safe_horizon = max(1, min(int(horizon), 120))
+            mode = str(strategy or "auto").strip().lower()
+            if mode not in {"auto", "registered", "fallback"}:
+                raise HTTPException(status_code=422, detail="strategy 仅支持 auto|registered|fallback")
 
-        selected = None
-        resolved_model_id = model_id or f"{event_type}.{metric}.{entity_id}"
-        if mode in {"auto", "registered"}:
-            selected = app.state.forecast_registry.resolve(resolved_model_id, version=model_version)
-            if selected is None and mode == "registered":
-                raise HTTPException(status_code=422, detail=f"model not found: {resolved_model_id}")
+            selected = None
+            resolved_model_id = model_id or f"{event_type}.{metric}.{entity_id}"
+            if mode in {"auto", "registered"}:
+                selected = app.state.forecast_registry.resolve(resolved_model_id, version=model_version)
+                if selected is None and mode == "registered":
+                    raise HTTPException(status_code=422, detail=f"model not found: {resolved_model_id}")
 
-        if selected is not None:
-            model_win = int(selected.raw.get("window") or selected.raw.get("params", {}).get("input_window") or window)
-            safe_window = max(3, min(model_win, len(values)))
-            baseline = _forecast_wma(values=values, window=safe_window, steps=safe_horizon)
-            model_type = f"lstm_{selected.backend}"
-            selected_version = selected.version
-            validation_mape = selected.validation_mape
-        else:
-            safe_window = max(3, min(int(window), len(values)))
-            baseline = _forecast_wma(values=values, window=safe_window, steps=safe_horizon)
-            model_type = "lstm_fallback_wma"
-            selected_version = "fallback"
-            validation_mape = None
+            if selected is not None:
+                model_win = int(
+                    selected.raw.get("window") or selected.raw.get("params", {}).get("input_window") or window
+                )
+                safe_window = max(3, min(model_win, len(values)))
+                baseline = _forecast_wma(values=values, window=safe_window, steps=safe_horizon)
+                model_type = f"lstm_{selected.backend}"
+                selected_version = selected.version
+                validation_mape = selected.validation_mape
+            else:
+                safe_window = max(3, min(int(window), len(values)))
+                baseline = _forecast_wma(values=values, window=safe_window, steps=safe_horizon)
+                model_type = "lstm_fallback_wma"
+                selected_version = "fallback"
+                validation_mape = None
 
-        latest = values[-1]
-        out = []
-        for idx, pred in enumerate(baseline, start=1):
-            spread = max(abs(pred - latest) * 0.15, abs(pred) * 0.05, 1e-6)
-            out.append(
-                {
-                    "step": idx,
-                    "yhat": round(pred, 6),
-                    "lower": round(pred - spread, 6),
-                    "upper": round(pred + spread, 6),
-                }
-            )
-        return {
-            "status": "ok",
-            "source": "timescaledb",
-            "model_type": model_type,
-            "model_id": resolved_model_id,
-            "model_version": selected_version,
-            "strategy": mode,
-            "event_type": event_type,
-            "metric": metric,
-            "entity_id": entity_id,
-            "topology_epoch": topology_epoch,
-            "history_points": len(values),
-            "validation_mape": validation_mape,
-            "window": safe_window,
-            "horizon": safe_horizon,
-            "points": out,
-        }
+            latest = values[-1]
+            out = []
+            for idx, pred in enumerate(baseline, start=1):
+                spread = max(abs(pred - latest) * 0.15, abs(pred) * 0.05, 1e-6)
+                out.append(
+                    {
+                        "step": idx,
+                        "yhat": round(pred, 6),
+                        "lower": round(pred - spread, 6),
+                        "upper": round(pred + spread, 6),
+                    }
+                )
+            ok = True
+            return {
+                "status": "ok",
+                "source": "timescaledb",
+                "model_type": model_type,
+                "model_id": resolved_model_id,
+                "model_version": selected_version,
+                "strategy": mode,
+                "event_type": event_type,
+                "metric": metric,
+                "entity_id": entity_id,
+                "topology_epoch": topology_epoch,
+                "history_points": len(values),
+                "validation_mape": validation_mape,
+                "window": safe_window,
+                "horizon": safe_horizon,
+                "points": out,
+            }
+        finally:
+            app.state.slo.record("forecast.lstm", ok=ok, latency_ms=(time.perf_counter() - start) * 1000.0)
 
     @app.get("/api/v1/analysis/forecast/models")
     async def list_forecast_models(model_id: Optional[str] = None) -> dict[str, object]:
@@ -242,39 +265,115 @@ def create_app() -> FastAPI:
     @app.post("/api/v1/fault/spread")
     @app.post("/api/v1/fault/spread/analyze")
     async def fault_spread(payload: dict[str, object]) -> dict[str, object]:
-        alarm_nodes = payload.get("alarm_nodes")
-        links = payload.get("links")
-        if not isinstance(alarm_nodes, list) or not isinstance(links, list):
-            raise HTTPException(status_code=422, detail="alarm_nodes(list) 与 links(list) 为必填")
-        mode = str(payload.get("mode", "single_point"))
-        if mode not in {"single_point", "cascade"}:
-            raise HTTPException(status_code=422, detail="mode 仅支持 single_point|cascade")
-        req = AnalyzeRequest(
-            alarm_nodes=[str(x) for x in alarm_nodes],
-            links=[x for x in links if isinstance(x, dict)],
-            max_depth=max(1, min(int(payload.get("max_depth", 3)), 8)),
-            mode=mode,
-            cascade_threshold=float(payload.get("cascade_threshold", 0.6)),
-        )
-        result = app.state.fault_spread.analyze(req)
-        return {"status": "ok", "result": result}
+        start = time.perf_counter()
+        ok = False
+        try:
+            alarm_nodes = payload.get("alarm_nodes")
+            links = payload.get("links")
+            if not isinstance(alarm_nodes, list) or not isinstance(links, list):
+                raise HTTPException(status_code=422, detail="alarm_nodes(list) 与 links(list) 为必填")
+            mode = str(payload.get("mode", "single_point"))
+            if mode not in {"single_point", "cascade"}:
+                raise HTTPException(status_code=422, detail="mode 仅支持 single_point|cascade")
+            req = AnalyzeRequest(
+                alarm_nodes=[str(x) for x in alarm_nodes],
+                links=[x for x in links if isinstance(x, dict)],
+                max_depth=max(1, min(int(payload.get("max_depth", 3)), 8)),
+                mode=mode,
+                cascade_threshold=float(payload.get("cascade_threshold", 0.6)),
+            )
+            result = app.state.fault_spread.analyze(req)
+            ok = True
+            return {"status": "ok", "result": result}
+        finally:
+            app.state.slo.record("fault.spread", ok=ok, latency_ms=(time.perf_counter() - start) * 1000.0)
 
     @app.post("/api/v1/fault/task-impact")
     @app.post("/api/v1/fault/task-impact/evaluate")
     async def fault_task_impact(payload: dict[str, object]) -> dict[str, object]:
-        tasks = payload.get("tasks")
-        link_metrics = payload.get("link_metrics")
-        if not isinstance(tasks, list) or not isinstance(link_metrics, dict):
-            raise HTTPException(status_code=422, detail="tasks(list) 与 link_metrics(dict) 为必填")
-        req = TaskImpactRequest(
-            tasks=[x for x in tasks if isinstance(x, dict)],
-            link_metrics={str(k): v for k, v in link_metrics.items() if isinstance(v, dict)},
-            fault_spread=payload.get("fault_spread") if isinstance(payload.get("fault_spread"), dict) else None,
-            rtt_warn_ms=float(payload.get("rtt_warn_ms", 180.0)),
-            loss_warn_rate=float(payload.get("loss_warn_rate", 0.03)),
-        )
-        result = app.state.task_impact.evaluate(req)
-        return {"status": "ok", "result": result}
+        start = time.perf_counter()
+        ok = False
+        try:
+            tasks = payload.get("tasks")
+            link_metrics = payload.get("link_metrics")
+            if not isinstance(tasks, list) or not isinstance(link_metrics, dict):
+                raise HTTPException(status_code=422, detail="tasks(list) 与 link_metrics(dict) 为必填")
+            req = TaskImpactRequest(
+                tasks=[x for x in tasks if isinstance(x, dict)],
+                link_metrics={str(k): v for k, v in link_metrics.items() if isinstance(v, dict)},
+                fault_spread=payload.get("fault_spread") if isinstance(payload.get("fault_spread"), dict) else None,
+                rtt_warn_ms=float(payload.get("rtt_warn_ms", 180.0)),
+                loss_warn_rate=float(payload.get("loss_warn_rate", 0.03)),
+            )
+            result = app.state.task_impact.evaluate(req)
+            ok = True
+            return {"status": "ok", "result": result}
+        finally:
+            app.state.slo.record("fault.task_impact", ok=ok, latency_ms=(time.perf_counter() - start) * 1000.0)
+
+    @app.get("/api/v1/ops/slo")
+    async def slo_metrics() -> dict[str, object]:
+        ingest = app.state.stats.snapshot()
+        api_slo = app.state.slo.snapshot().get("by_api", {})
+        db_write_failed = int(ingest.get("by_code", {}).get("DB_WRITE_FAILED", 0))
+        ingest_total = int(ingest.get("total", 0))
+        db_slo = {
+            "write_attempts_approx": ingest_total,
+            "write_failed": db_write_failed,
+            "write_error_rate": round(db_write_failed / ingest_total, 4) if ingest_total else 0.0,
+        }
+
+        def _collect(keys: list[str]) -> dict[str, object]:
+            total = 0
+            ok_count = 0
+            error_count = 0
+            p95_candidates: list[float] = []
+            for key in keys:
+                item = api_slo.get(key) or {}
+                total += int(item.get("total", 0))
+                ok_count += int(item.get("ok", 0))
+                error_count += int(item.get("error", 0))
+                p95 = float(item.get("latency_ms_p95", 0.0))
+                if p95 > 0:
+                    p95_candidates.append(p95)
+            return {
+                "total": total,
+                "ok": ok_count,
+                "error": error_count,
+                "availability": round(ok_count / total, 4) if total else 1.0,
+                "error_rate": round(error_count / total, 4) if total else 0.0,
+                "latency_ms_p95_worst": max(p95_candidates) if p95_candidates else 0.0,
+            }
+
+        query_slo = _collect(["query.snapshot", "query.series"])
+        forecast_slo = _collect(["forecast.lstm"])
+        fault_slo = _collect(["fault.spread", "fault.task_impact"])
+        objectives = {
+            "availability_min": 0.99,
+            "error_rate_max": 0.01,
+            "latency_ms_p95_max": 200.0,
+        }
+
+        def _judge(s: dict[str, object]) -> dict[str, object]:
+            availability = float(s.get("availability", 1.0))
+            error_rate = float(s.get("error_rate", 0.0))
+            p95 = float(s.get("latency_ms_p95_worst", 0.0))
+            return {
+                "availability_ok": availability >= objectives["availability_min"],
+                "error_rate_ok": error_rate <= objectives["error_rate_max"],
+                "latency_ok": p95 <= objectives["latency_ms_p95_max"] if p95 > 0 else True,
+            }
+
+        return {
+            "status": "ok",
+            "objectives": objectives,
+            "ingest": ingest,
+            "db": db_slo,
+            "query": {**query_slo, "judge": _judge(query_slo)},
+            "forecast": {**forecast_slo, "judge": _judge(forecast_slo)},
+            "fault": {**fault_slo, "judge": _judge(fault_slo)},
+            "by_api": api_slo,
+        }
 
     @app.get("/api/v1/bff/snapshot")
     async def bff_snapshot(

--- a/src/collector/app/observability.py
+++ b/src/collector/app/observability.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from collections import Counter
+from dataclasses import dataclass
+from statistics import mean
 from threading import Lock
+from typing import Any
 
 
 class OutcomeStats:
@@ -33,3 +36,74 @@ class OutcomeStats:
             "fail_rate": fail_rate,
             "by_code": counts,
         }
+
+
+@dataclass
+class _SLOBucket:
+    total: int = 0
+    ok: int = 0
+    error: int = 0
+    latencies_ms: list[float] | None = None
+
+    def __post_init__(self) -> None:
+        if self.latencies_ms is None:
+            self.latencies_ms = []
+
+
+def _percentile(values: list[float], q: float) -> float:
+    if not values:
+        return 0.0
+    xs = sorted(values)
+    idx = int(max(0, min(len(xs) - 1, round((len(xs) - 1) * q))))
+    return float(xs[idx])
+
+
+class ApiSLOTracker:
+    def __init__(self, max_samples_per_api: int = 2000) -> None:
+        self._lock = Lock()
+        self._max_samples = max(100, int(max_samples_per_api))
+        self._buckets: dict[str, _SLOBucket] = {}
+
+    def record(self, api: str, ok: bool, latency_ms: float) -> None:
+        k = str(api or "").strip() or "unknown"
+        v = max(0.0, float(latency_ms))
+        with self._lock:
+            bucket = self._buckets.setdefault(k, _SLOBucket())
+            bucket.total += 1
+            if ok:
+                bucket.ok += 1
+            else:
+                bucket.error += 1
+            bucket.latencies_ms.append(v)
+            if len(bucket.latencies_ms) > self._max_samples:
+                del bucket.latencies_ms[: len(bucket.latencies_ms) - self._max_samples]
+
+    def snapshot(self) -> dict[str, Any]:
+        with self._lock:
+            data = {
+                key: _SLOBucket(
+                    total=value.total,
+                    ok=value.ok,
+                    error=value.error,
+                    latencies_ms=list(value.latencies_ms or []),
+                )
+                for key, value in self._buckets.items()
+            }
+
+        by_api: dict[str, dict[str, Any]] = {}
+        for key, value in data.items():
+            total = value.total
+            ok = value.ok
+            error = value.error
+            latencies = value.latencies_ms or []
+            by_api[key] = {
+                "total": total,
+                "ok": ok,
+                "error": error,
+                "availability": round(ok / total, 4) if total else 1.0,
+                "error_rate": round(error / total, 4) if total else 0.0,
+                "latency_ms_avg": round(mean(latencies), 3) if latencies else 0.0,
+                "latency_ms_p95": round(_percentile(latencies, 0.95), 3) if latencies else 0.0,
+            }
+
+        return {"by_api": by_api}

--- a/src/collector/scripts/test_slo_api.py
+++ b/src/collector/scripts/test_slo_api.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+import httpx
+
+os.environ.setdefault("TSDB_ENABLED", "false")
+os.environ.setdefault("NATS_URL", "nats://127.0.0.1:4222")
+os.environ.setdefault("FORECAST_MODEL_DIR", "/tmp/forecast_models/lstm")
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.main import create_app
+
+
+class DummyTSWriter:
+    def is_ready(self) -> bool:
+        return True
+
+    def read_metric_series(self, event_type: str, metric: str, entity_id: str, limit: int, topology_epoch: str | None = None):
+        return [
+            {"ts": "2026-02-26T12:00:00Z", "value": 10.0},
+            {"ts": "2026-02-26T12:01:00Z", "value": 11.0},
+            {"ts": "2026-02-26T12:02:00Z", "value": 10.5},
+            {"ts": "2026-02-26T12:03:00Z", "value": 12.0},
+            {"ts": "2026-02-26T12:04:00Z", "value": 11.8},
+        ][: max(1, int(limit))]
+
+
+async def main() -> None:
+    app = create_app()
+    app.state.ts_writer = DummyTSWriter()
+
+    spread_payload = {
+        "alarm_nodes": ["SAT-INCL-001"],
+        "links": [
+            {"src": "SAT-INCL-001", "dst": "SAT-INCL-011", "health": 0.40},
+            {"src": "SAT-INCL-011", "dst": "GW-EDGE-001", "health": 0.55},
+        ],
+    }
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://collector") as client:
+        await client.get("/api/v1/bff/snapshot")
+        await client.get(
+            "/api/v1/bff/series",
+            params={"event_type": "link_metric", "metric": "rtt_ms", "entity_id": "SAT-INCL-001<->SAT-INCL-011"},
+        )
+        await client.get(
+            "/api/v1/bff/forecast/lstm",
+            params={
+                "event_type": "link_metric",
+                "metric": "rtt_ms",
+                "entity_id": "SAT-INCL-001<->SAT-INCL-011",
+                "strategy": "fallback",
+            },
+        )
+        spread = await client.post("/api/v1/bff/fault/spread", json=spread_payload)
+        spread_result = spread.json().get("result", {})
+        await client.post(
+            "/api/v1/bff/fault/task-impact",
+            json={
+                "tasks": [{"task_id": "task-1", "links": ["SAT-INCL-001<->SAT-INCL-011"]}],
+                "link_metrics": {"SAT-INCL-001<->SAT-INCL-011": {"state": "DOWN", "rtt_ms": 333, "loss_rate": 0.1}},
+                "fault_spread": spread_result,
+            },
+        )
+
+        slo = await client.get("/api/v1/ops/slo")
+        assert slo.status_code == 200, slo.text
+        payload = slo.json()
+        for key in ["ingest", "db", "query", "forecast", "fault", "by_api", "objectives"]:
+            assert key in payload, f"missing key: {key}"
+        assert payload["query"]["total"] >= 1
+        assert payload["forecast"]["total"] >= 1
+        assert payload["fault"]["total"] >= 2
+
+    print("slo_api_test_ok")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## 背景
实现 I-037：建立 query/forecast/fault 的延迟与错误率观测，并提供统一 SLO 汇总接口。

## 变更内容
- 扩展 `src/collector/app/observability.py`
  - 新增 `ApiSLOTracker`
  - 记录 API 调用总量、成功/失败、平均延迟、P95 延迟
- 更新 `src/collector/app/main.py`
  - 为 snapshot/series/forecast/fault 关键接口增加 SLO 打点
  - 新增 `GET /api/v1/ops/slo`
    - 汇总维度：`ingest/db/query/forecast/fault`
    - 输出 SLO 目标、聚合统计、判定结果、按 API 细分
- 新增 `src/collector/scripts/test_slo_api.py`（API 级验证）
- 更新 `src/collector/README.md`（SLO 接口与测试命令）

## 验证
- `python scripts/test_fault_api.py`
  - `fault_api_test_ok: avg_ms=0.554, p95_ms=0.604, n=200`
- `python scripts/test_bff_api.py`
  - `bff_api_test_ok`
- `python scripts/test_slo_api.py`
  - `slo_api_test_ok`

## DoD 对照
1. 指标覆盖 ingest/db/query/forecast/fault（汇总视角）
2. 提供可用性/错误率/P95 延迟观测
3. 支持快速判断是否满足 SLO 目标
4. 提供可复用联调验证脚本

## Git Flow
- 分支：`feature/I-037-observability-slo`
- 目标：`develop`
