### PR TITLE
feat: I-041 统一高级分析入口 analysis/run（轻参数）

### DIFF
--- a/src/collector/README.md
+++ b/src/collector/README.md
@@ -130,3 +130,12 @@
 
 ## 全局分析自测
 - `python scripts/test_global_impact_api.py`
+
+## 统一高级分析入口（I-041）
+- `POST /api/v1/bff/analysis/run`
+  - 前端轻量参数：`mode/scope_type/scope_id/topology_epoch`
+  - 后端自动执行：告警发现 -> 传播分析 -> 任务影响评估
+  - 返回：`summary/topology_impact/tasks/alerts/meta`
+
+## 统一入口自测
+- `python scripts/test_analysis_run_api.py`

--- a/src/collector/app/main.py
+++ b/src/collector/app/main.py
@@ -581,6 +581,80 @@ def create_app() -> FastAPI:
         finally:
             app.state.slo.record("analysis.global_impact", ok=ok, latency_ms=(time.perf_counter() - start) * 1000.0)
 
+    @app.post("/api/v1/bff/analysis/run")
+    async def bff_analysis_run(payload: dict[str, object]) -> dict[str, object]:
+        start = time.perf_counter()
+        ok = False
+        try:
+            mode = str(payload.get("mode", "auto")).strip().lower()
+            if mode not in {"auto", "focused", "global"}:
+                raise HTTPException(status_code=422, detail="INVALID_SCOPE: mode 仅支持 auto|focused|global")
+            scope_type = str(payload.get("scope_type", "network")).strip().lower()
+            scope_id = str(payload.get("scope_id", "all")).strip()
+
+            if mode == "auto":
+                if scope_type in {"node", "link"} and scope_id not in {"", "all"}:
+                    mode = "focused"
+                else:
+                    mode = "global"
+                    scope_type = "network"
+                    scope_id = "all"
+            elif mode == "global":
+                scope_type = "network"
+                scope_id = "all"
+
+            if mode == "focused" and (scope_type not in {"node", "link"} or scope_id in {"", "all"}):
+                raise HTTPException(status_code=422, detail="INVALID_SCOPE: focused 需提供 node/link 的 scope_id")
+
+            run_payload = {
+                "mode": mode,
+                "scope_type": scope_type,
+                "scope_id": scope_id,
+                "topology_epoch": payload.get("topology_epoch"),
+                "strategies": payload.get("strategies") or ["threshold", "baseline"],
+                "window_sec": payload.get("window_sec", 300),
+                "max_depth": payload.get("max_depth", 4),
+                "spread_mode": payload.get("spread_mode", "cascade"),
+                "cascade_threshold": payload.get("cascade_threshold", 0.6),
+                "rtt_warn_ms": payload.get("rtt_warn_ms", 180.0),
+                "loss_warn_rate": payload.get("loss_warn_rate", 0.03),
+                "max_tasks": payload.get("max_tasks", 30),
+            }
+            result = await bff_global_impact(run_payload)
+            out = {
+                "status": "ok",
+                "contract_version": "analysis.v1",
+                "input": {
+                    "mode": str(payload.get("mode", "auto")).strip().lower(),
+                    "scope_type": str(payload.get("scope_type", "network")).strip().lower(),
+                    "scope_id": str(payload.get("scope_id", "all")).strip(),
+                    "topology_epoch": payload.get("topology_epoch"),
+                },
+                "resolved": {
+                    "mode": mode,
+                    "scope_type": scope_type,
+                    "scope_id": scope_id,
+                },
+                "summary": result.get("summary"),
+                "topology_impact": {
+                    "seed_nodes": (result.get("seeds") or {}).get("alarm_nodes", []),
+                    "seed_links": (result.get("seeds") or {}).get("alarm_links", []),
+                    "impacted_nodes": (result.get("impact_graph") or {}).get("impacted_nodes", []),
+                    "impacted_links": (result.get("impact_graph") or {}).get("impacted_links", []),
+                    "boundary_nodes": (result.get("impact_graph") or {}).get("boundary_nodes", []),
+                },
+                "tasks": (result.get("task_impacts") or {}).get("tasks", []),
+                "alerts": [x.get("alert_item") for x in ((result.get("task_impacts") or {}).get("tasks") or []) if isinstance(x, dict)],
+                "meta": {
+                    "detected_alarm_total": len(result.get("detected_alarms") or []),
+                    "task_total": len(((result.get("task_impacts") or {}).get("tasks") or [])),
+                },
+            }
+            ok = True
+            return out
+        finally:
+            app.state.slo.record("analysis.run", ok=ok, latency_ms=(time.perf_counter() - start) * 1000.0)
+
     @app.post("/api/v1/ops/failed-events/replay")
     async def replay_failed_events(limit: int = 50) -> dict[str, object]:
         ids = app.state.failed_events.pending_event_ids(limit=limit)

--- a/src/collector/scripts/test_analysis_run_api.py
+++ b/src/collector/scripts/test_analysis_run_api.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+import httpx
+
+os.environ.setdefault("TSDB_ENABLED", "false")
+os.environ.setdefault("NATS_URL", "nats://127.0.0.1:4222")
+os.environ.setdefault("FORECAST_MODEL_DIR", "/tmp/forecast_models/lstm")
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.main import create_app
+
+
+def seed_snapshot(app) -> None:
+    nodes = [
+        ("SAT-POLAR-001", 0.92, 0.81),
+        ("SAT-POLAR-002", 0.44, 0.46),
+        ("SAT-POLAR-003", 0.38, 0.41),
+    ]
+    for idx, (nid, cpu, mem) in enumerate(nodes, start=1):
+        app.state.snapshot_store.apply(
+            "node_metric",
+            {
+                "schema_version": "monitor.v1",
+                "message_id": f"r-node-{idx}",
+                "timestamp": "2026-02-26T12:00:00Z",
+                "topology_epoch": "1708848000",
+                "node_uid": nid,
+                "node_id": nid,
+                "cpu_ratio": cpu,
+                "mem_ratio": mem,
+                "status": "UP",
+            },
+        )
+    app.state.snapshot_store.apply(
+        "link_metric",
+        {
+            "schema_version": "monitor.v1",
+            "message_id": "r-link-1",
+            "timestamp": "2026-02-26T12:00:00Z",
+            "topology_epoch": "1708848000",
+            "link_uid": "SAT-POLAR-001<->SAT-POLAR-002",
+            "link_id": "SAT-POLAR-001-SAT-POLAR-002",
+            "src_node_uid": "SAT-POLAR-001",
+            "dst_node_uid": "SAT-POLAR-002",
+            "src_node_id": "SAT-POLAR-001",
+            "dst_node_id": "SAT-POLAR-002",
+            "state": "UP",
+            "loss_rate": 0.041,
+            "rtt_ms": 220,
+            "jitter_ms": 14,
+        },
+    )
+    app.state.snapshot_store.apply(
+        "link_metric",
+        {
+            "schema_version": "monitor.v1",
+            "message_id": "r-link-2",
+            "timestamp": "2026-02-26T12:00:00Z",
+            "topology_epoch": "1708848000",
+            "link_uid": "SAT-POLAR-002<->SAT-POLAR-003",
+            "link_id": "SAT-POLAR-002-SAT-POLAR-003",
+            "src_node_uid": "SAT-POLAR-002",
+            "dst_node_uid": "SAT-POLAR-003",
+            "src_node_id": "SAT-POLAR-002",
+            "dst_node_id": "SAT-POLAR-003",
+            "state": "DEGRADED",
+            "loss_rate": 0.021,
+            "rtt_ms": 170,
+            "jitter_ms": 10,
+        },
+    )
+
+
+async def main() -> None:
+    app = create_app()
+    seed_snapshot(app)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://collector") as client:
+        # global
+        r1 = await client.post(
+            "/api/v1/bff/analysis/run",
+            json={
+                "mode": "global",
+                "scope_type": "network",
+                "scope_id": "all",
+                "topology_epoch": "1708848000",
+            },
+        )
+        assert r1.status_code == 200, r1.text
+        b1 = r1.json()
+        assert b1.get("resolved", {}).get("mode") == "global"
+        assert isinstance(b1.get("tasks"), list)
+
+        # focused-link
+        r2 = await client.post(
+            "/api/v1/bff/analysis/run",
+            json={
+                "mode": "focused",
+                "scope_type": "link",
+                "scope_id": "SAT-POLAR-001<->SAT-POLAR-002",
+                "topology_epoch": "1708848000",
+            },
+        )
+        assert r2.status_code == 200, r2.text
+        b2 = r2.json()
+        assert b2.get("resolved", {}).get("scope_type") == "link"
+
+        # auto
+        r3 = await client.post(
+            "/api/v1/bff/analysis/run",
+            json={
+                "mode": "auto",
+                "scope_type": "link",
+                "scope_id": "SAT-POLAR-001<->SAT-POLAR-002",
+                "topology_epoch": "1708848000",
+            },
+        )
+        assert r3.status_code == 200, r3.text
+        b3 = r3.json()
+        assert b3.get("resolved", {}).get("mode") == "focused"
+        assert "summary" in b3 and "topology_impact" in b3
+
+    print("analysis_run_api_test_ok")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## 背景
按 I-041 目标，为前端提供统一高级分析入口，避免前端传 `links/tasks/link_metrics/alarm_nodes` 大包。

## 变更内容
- 更新 `src/collector/app/main.py`
  - 新增 `POST /api/v1/bff/analysis/run`
  - 仅需轻量输入：`mode/scope_type/scope_id/topology_epoch`
  - 内部复用全局分析流水线：告警发现 -> 传播分析 -> 任务影响评估
  - 支持 `mode=auto|focused|global`
  - 返回聚合结构：`summary/topology_impact/tasks/alerts/meta`
  - 新增 SLO 打点：`analysis.run`
- 新增 `src/collector/scripts/test_analysis_run_api.py`
  - 覆盖 `global/focused/auto` 三种调用
- 更新 `src/collector/README.md`
  - 补充 `analysis/run` 说明与测试命令

## 验证
- `python scripts/test_analysis_run_api.py` -> `analysis_run_api_test_ok`
- `python scripts/test_global_impact_api.py` -> `global_impact_api_test_ok`
- `python scripts/test_alarm_discovery_api.py` -> `alarm_discovery_api_test_ok`

## DoD 对照
1. 前端无需传重数据包即可完成高级分析
2. 统一错误入口与响应语义
3. 与 I-039/I-040 能力链路可联动
4. 提供可复用自动化自测

## Git Flow
- 分支：`feature/I-041-analysis-run-api`
- 目标：`develop`
