### PR TITLE
feat: I-043 前端契约冻结与联调验收（analysis.v1）

### DIFF
--- a/src/collector/README.md
+++ b/src/collector/README.md
@@ -152,3 +152,8 @@
 
 ## 推演自测
 - `python scripts/test_simulation_api.py`
+
+## 前端契约冻结（I-043）
+- 契约文档：`src/collector/docs/analysis_contract_v1.md`
+- 验收脚本：`python scripts/test_frontend_contract_acceptance.py`
+  - 覆盖：`focused(node/link)`、`global(network)`、错误码 `INVALID_SCOPE`

--- a/src/collector/app/main.py
+++ b/src/collector/app/main.py
@@ -478,18 +478,24 @@ def create_app() -> FastAPI:
             topology_epoch = str(payload.get("topology_epoch")) if payload.get("topology_epoch") not in (None, "") else None
             mode = str(payload.get("mode", "global")).strip().lower()
             if mode not in {"global", "focused", "auto"}:
-                raise HTTPException(status_code=422, detail="mode 仅支持 global|focused|auto")
+                raise HTTPException(status_code=422, detail=_analysis_error("INVALID_SCOPE", "mode 仅支持 global|focused|auto"))
             scope_type = str(payload.get("scope_type", "network")).strip().lower()
             scope_id = str(payload.get("scope_id", "all")).strip()
             if scope_type not in {"network", "node", "link"}:
-                raise HTTPException(status_code=422, detail="scope_type 仅支持 network|node|link")
+                raise HTTPException(
+                    status_code=422,
+                    detail=_analysis_error("INVALID_SCOPE", "scope_type 仅支持 network|node|link"),
+                )
 
             snapshot_payload = app.state.snapshot_store.snapshot(topology_epoch=topology_epoch)
             monitor = snapshot_payload.get("monitor", {}) if isinstance(snapshot_payload, dict) else {}
             links_map = monitor.get("links", {}) if isinstance(monitor.get("links"), dict) else {}
             links = [x for x in links_map.values() if isinstance(x, dict)]
             if not links:
-                raise HTTPException(status_code=422, detail="INSUFFICIENT_DATA: no topology links in snapshot")
+                raise HTTPException(
+                    status_code=422,
+                    detail=_analysis_error("INSUFFICIENT_DATA", "no topology links in snapshot"),
+                )
 
             alarm_scope_type = scope_type if mode == "focused" else "network"
             alarm_scope_id = scope_id if mode == "focused" else "all"
@@ -590,7 +596,10 @@ def create_app() -> FastAPI:
         try:
             mode = str(payload.get("mode", "auto")).strip().lower()
             if mode not in {"auto", "focused", "global"}:
-                raise HTTPException(status_code=422, detail="INVALID_SCOPE: mode 仅支持 auto|focused|global")
+                raise HTTPException(
+                    status_code=422,
+                    detail=_analysis_error("INVALID_SCOPE", "mode 仅支持 auto|focused|global"),
+                )
             scope_type = str(payload.get("scope_type", "network")).strip().lower()
             scope_id = str(payload.get("scope_id", "all")).strip()
 
@@ -606,7 +615,10 @@ def create_app() -> FastAPI:
                 scope_id = "all"
 
             if mode == "focused" and (scope_type not in {"node", "link"} or scope_id in {"", "all"}):
-                raise HTTPException(status_code=422, detail="INVALID_SCOPE: focused 需提供 node/link 的 scope_id")
+                raise HTTPException(
+                    status_code=422,
+                    detail=_analysis_error("INVALID_SCOPE", "focused 需提供 node/link 的 scope_id"),
+                )
 
             run_payload = {
                 "mode": mode,
@@ -622,7 +634,16 @@ def create_app() -> FastAPI:
                 "loss_warn_rate": payload.get("loss_warn_rate", 0.03),
                 "max_tasks": payload.get("max_tasks", 30),
             }
-            result = await bff_global_impact(run_payload)
+            try:
+                result = await bff_global_impact(run_payload)
+            except HTTPException as exc:
+                code, msg = _normalize_analysis_exception(exc)
+                raise HTTPException(status_code=422, detail=_analysis_error(code, msg)) from exc
+            except Exception as exc:  # noqa: BLE001
+                raise HTTPException(
+                    status_code=500,
+                    detail=_analysis_error("INTERNAL_ERROR", f"analysis run failed: {exc}"),
+                ) from exc
             out = {
                 "status": "ok",
                 "contract_version": "analysis.v1",
@@ -778,6 +799,24 @@ def _forecast_wma(values: list[float], window: int, steps: int) -> list[float]:
         out.append(float(weighted))
         hist.append(float(weighted))
     return out
+
+
+def _analysis_error(code: str, message: str) -> dict[str, str]:
+    return {"error_code": str(code), "error_message": str(message)}
+
+
+def _normalize_analysis_exception(exc: HTTPException) -> tuple[str, str]:
+    detail = exc.detail
+    if isinstance(detail, dict):
+        code = str(detail.get("error_code") or "INTERNAL_ERROR")
+        msg = str(detail.get("error_message") or detail.get("detail") or "analysis error")
+        return code, msg
+    text = str(detail or "analysis error")
+    if text.startswith("INVALID_SCOPE"):
+        return "INVALID_SCOPE", text.split(":", 1)[-1].strip() if ":" in text else text
+    if text.startswith("INSUFFICIENT_DATA"):
+        return "INSUFFICIENT_DATA", text.split(":", 1)[-1].strip() if ":" in text else text
+    return "INTERNAL_ERROR", text
 
 
 def _extract_seeds(detected_alarms: list[dict[str, Any]]) -> tuple[list[str], list[str]]:

--- a/src/collector/docs/analysis_contract_v1.md
+++ b/src/collector/docs/analysis_contract_v1.md
@@ -1,0 +1,51 @@
+# 高级分析契约冻结（analysis.v1）
+
+更新时间：2026-02-26  
+状态：`frozen-for-frontend`
+
+## 1. 统一入口
+
+- `POST /api/v1/bff/analysis/run`
+
+前端只传轻量参数：
+- `mode`: `auto|focused|global`
+- `scope_type`: `node|link|network`
+- `scope_id`: `NODE_ID | A<->B | all`
+- `topology_epoch`
+
+## 2. 响应结构（前端可依赖）
+
+- `status`
+- `contract_version`（固定 `analysis.v1`）
+- `input`（前端传入）
+- `resolved`（后端实际执行模式）
+- `summary`
+- `topology_impact`
+- `tasks`
+- `alerts`
+- `meta`
+
+## 3. 错误模型（固定三类）
+
+后端在 4xx/5xx 时返回：
+```json
+{
+  "detail": {
+    "error_code": "INVALID_SCOPE|INSUFFICIENT_DATA|INTERNAL_ERROR",
+    "error_message": "..."
+  }
+}
+```
+
+语义：
+- `INVALID_SCOPE`：前端传参语义错误
+- `INSUFFICIENT_DATA`：后端数据不足无法分析
+- `INTERNAL_ERROR`：后端内部异常
+
+## 4. 前端验收清单
+
+1. `focused + node` 返回 200  
+2. `focused + link` 返回 200  
+3. `global + network` 返回 200  
+4. 非法 scope 触发 `INVALID_SCOPE`  
+5. 页面只依赖 `summary/topology_impact/tasks/alerts` 渲染

--- a/src/collector/scripts/test_frontend_contract_acceptance.py
+++ b/src/collector/scripts/test_frontend_contract_acceptance.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+import httpx
+
+os.environ.setdefault("TSDB_ENABLED", "false")
+os.environ.setdefault("NATS_URL", "nats://127.0.0.1:4222")
+os.environ.setdefault("FORECAST_MODEL_DIR", "/tmp/forecast_models/lstm")
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.main import create_app
+
+
+def seed_snapshot(app) -> None:
+    for nid, cpu, mem in [
+        ("SAT-INCL-001", 0.93, 0.72),
+        ("SAT-INCL-011", 0.42, 0.45),
+        ("SAT-INCL-091", 0.36, 0.41),
+    ]:
+        app.state.snapshot_store.apply(
+            "node_metric",
+            {
+                "schema_version": "monitor.v1",
+                "message_id": f"fc-node-{nid}",
+                "timestamp": "2026-02-26T14:00:00Z",
+                "topology_epoch": "1708848000",
+                "node_uid": nid,
+                "node_id": nid,
+                "cpu_ratio": cpu,
+                "mem_ratio": mem,
+                "status": "UP",
+            },
+        )
+
+    for uid, lid, src, dst, loss, rtt in [
+        ("SAT-INCL-001<->SAT-INCL-011", "SAT-INCL-001-SAT-INCL-011", "SAT-INCL-001", "SAT-INCL-011", 0.045, 225),
+        ("SAT-INCL-011<->SAT-INCL-091", "SAT-INCL-011-SAT-INCL-091", "SAT-INCL-011", "SAT-INCL-091", 0.014, 120),
+    ]:
+        app.state.snapshot_store.apply(
+            "link_metric",
+            {
+                "schema_version": "monitor.v1",
+                "message_id": f"fc-link-{lid}",
+                "timestamp": "2026-02-26T14:00:00Z",
+                "topology_epoch": "1708848000",
+                "link_uid": uid,
+                "link_id": lid,
+                "src_node_uid": src,
+                "dst_node_uid": dst,
+                "src_node_id": src,
+                "dst_node_id": dst,
+                "state": "UP",
+                "loss_rate": loss,
+                "rtt_ms": rtt,
+                "jitter_ms": 8,
+            },
+        )
+
+
+def assert_contract(body: dict) -> None:
+    for key in ["status", "contract_version", "summary", "topology_impact", "tasks", "alerts", "meta"]:
+        assert key in body, f"missing key: {key}"
+    assert body.get("contract_version") == "analysis.v1"
+
+
+async def main() -> None:
+    app = create_app()
+    seed_snapshot(app)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://collector") as client:
+        # focused node
+        n = await client.post(
+            "/api/v1/bff/analysis/run",
+            json={
+                "mode": "focused",
+                "scope_type": "node",
+                "scope_id": "SAT-INCL-001",
+                "topology_epoch": "1708848000",
+            },
+        )
+        assert n.status_code == 200, n.text
+        assert_contract(n.json())
+
+        # focused link
+        l = await client.post(
+            "/api/v1/bff/analysis/run",
+            json={
+                "mode": "focused",
+                "scope_type": "link",
+                "scope_id": "SAT-INCL-001<->SAT-INCL-011",
+                "topology_epoch": "1708848000",
+            },
+        )
+        assert l.status_code == 200, l.text
+        assert_contract(l.json())
+
+        # global
+        g = await client.post(
+            "/api/v1/bff/analysis/run",
+            json={
+                "mode": "global",
+                "scope_type": "network",
+                "scope_id": "all",
+                "topology_epoch": "1708848000",
+            },
+        )
+        assert g.status_code == 200, g.text
+        assert_contract(g.json())
+
+        # invalid scope -> INVALID_SCOPE
+        bad = await client.post(
+            "/api/v1/bff/analysis/run",
+            json={
+                "mode": "focused",
+                "scope_type": "network",
+                "scope_id": "all",
+                "topology_epoch": "1708848000",
+            },
+        )
+        assert bad.status_code == 422, bad.text
+        detail = bad.json().get("detail", {})
+        assert isinstance(detail, dict)
+        assert detail.get("error_code") == "INVALID_SCOPE"
+
+    print("frontend_contract_acceptance_ok")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## 背景
按 I-043 目标冻结前端高级分析契约，收敛错误码，补齐联调验收。

## 变更内容
- 更新 `src/collector/app/main.py`
  - `analysis/global-impact` 与 `analysis/run` 错误返回统一为结构化 detail：
    - `INVALID_SCOPE`
    - `INSUFFICIENT_DATA`
    - `INTERNAL_ERROR`
- 新增 `src/collector/docs/analysis_contract_v1.md`
  - 冻结前端可依赖字段与错误模型
- 新增 `src/collector/scripts/test_frontend_contract_acceptance.py`
  - 验收三入口：`focused(node)` / `focused(link)` / `global(network)`
  - 验证错误码：`INVALID_SCOPE`
- 更新 `src/collector/README.md`
  - 补充 I-043 契约与验收脚本说明

## 验证
- `python scripts/test_frontend_contract_acceptance.py` -> `frontend_contract_acceptance_ok`
- `python scripts/test_analysis_run_api.py` -> `analysis_run_api_test_ok`
- `python scripts/test_simulation_api.py` -> `simulation_api_test_ok`

## DoD 对照
1. 前端契约字段冻结（analysis.v1）
2. 三类入口联调可复现
3. 错误码语义稳定
4. 验收脚本可复用

## Git Flow
- 分支：`feature/I-043-frontend-contract-freeze`
- 目标：`develop`
