### PR TITLE
[I-040] 预测解释增强与可信度分级

### DIFF
--- a/src/collector/app/main.py
+++ b/src/collector/app/main.py
@@ -251,6 +251,8 @@ def create_app() -> FastAPI:
                     "topology_epoch": topology_epoch,
                     "history_points": len(points),
                     "validation_mape": None,
+                    "metrics": {"mape": None, "rmse": None},
+                    "confidence": {"level": "unknown", "reason": "insufficient_history"},
                     "window": max(3, min(int(window), 120)),
                     "horizon": max(1, min(int(horizon), 120)),
                     "points": [],
@@ -298,6 +300,8 @@ def create_app() -> FastAPI:
                         "upper": round(pred + spread, 6),
                     }
                 )
+            est_mape, est_rmse = _estimate_forecast_error(values=values, window=safe_window)
+            confidence = _forecast_confidence_level(validation_mape=validation_mape, est_mape=est_mape)
             ok = True
             return {
                 "status": "ok",
@@ -312,6 +316,8 @@ def create_app() -> FastAPI:
                 "topology_epoch": topology_epoch,
                 "history_points": len(values),
                 "validation_mape": validation_mape,
+                "metrics": {"mape": est_mape, "rmse": est_rmse},
+                "confidence": {"level": confidence, "reason": "validation_mape_first"},
                 "window": safe_window,
                 "horizon": safe_horizon,
                 "points": out,
@@ -1238,6 +1244,7 @@ def _build_ollama_analysis_prompt(
     tasks = analysis.get("tasks") if isinstance(analysis.get("tasks"), list) else []
     extra_obj = extra_context if isinstance(extra_context, dict) else {}
     obs = extra_obj.get("scope_observation") if isinstance(extra_obj.get("scope_observation"), dict) else {}
+    fc = extra_obj.get("forecast_context") if isinstance(extra_obj.get("forecast_context"), dict) else {}
     impacted_nodes = topo.get("impacted_nodes") if isinstance(topo.get("impacted_nodes"), list) else []
     impacted_links = topo.get("impacted_links") if isinstance(topo.get("impacted_links"), list) else []
     findings_all = [x for x in (reasoning.get("top_findings") or []) if isinstance(x, dict)]
@@ -1258,6 +1265,7 @@ def _build_ollama_analysis_prompt(
         "next_action": narrative.get("next_action"),
         "tasks_top10": tasks[:10],
         "scope_observation": obs,
+        "forecast_context": fc,
         "direct_reason_hint": extra_obj.get("direct_reason"),
         "extra_context": extra_obj,
     }
@@ -2385,6 +2393,40 @@ def _parse_any_timestamp(ts: Any) -> float | None:
         return datetime.fromisoformat(raw).timestamp()
     except ValueError:
         return None
+
+
+def _estimate_forecast_error(*, values: list[float], window: int) -> tuple[float | None, float | None]:
+    if len(values) < max(6, window + 2):
+        return None, None
+    preds: list[float] = []
+    actuals: list[float] = []
+    for i in range(window, len(values)):
+        hist = values[:i]
+        pred = _forecast_wma(values=hist, window=min(window, len(hist)), steps=1)[0]
+        preds.append(float(pred))
+        actuals.append(float(values[i]))
+    if not preds:
+        return None, None
+    ape: list[float] = []
+    se_sum = 0.0
+    for p, a in zip(preds, actuals):
+        if abs(a) > 1e-9:
+            ape.append(abs((a - p) / a))
+        se_sum += (a - p) ** 2
+    mape = round(sum(ape) / len(ape), 6) if ape else None
+    rmse = round((se_sum / len(preds)) ** 0.5, 6)
+    return mape, rmse
+
+
+def _forecast_confidence_level(*, validation_mape: float | None, est_mape: float | None) -> str:
+    m = validation_mape if isinstance(validation_mape, (int, float)) else est_mape
+    if m is None:
+        return "unknown"
+    if m <= 0.12:
+        return "high"
+    if m <= 0.25:
+        return "medium"
+    return "low"
 
 
 def _safe_float(v: Any) -> float:

--- a/src/collector/docs/I-040_实施设计.md
+++ b/src/collector/docs/I-040_实施设计.md
@@ -1,0 +1,29 @@
+# I-040 实施设计：预测解释增强（趋势偏差、可信度、证据链）
+
+## 1. 目标
+在现有 `forecast/lstm` 与 `analysis/explain` 基础上，增加预测误差指标和可信度分级，并把预测上下文透传到 AI 解释，提升报告可解释性。
+
+## 2. 变更范围
+1. 后端 `GET /api/v1/analysis/forecast/lstm` 与 `GET /api/v1/bff/forecast/lstm` 增加：
+   - `metrics.mape`
+   - `metrics.rmse`
+   - `confidence.level`
+2. 前端“运行分析”流程先拉取预测，再调用 explain，确保 `forecast_context` 是本次最新数据。
+3. AI Prompt 输入中显式纳入 `forecast_context`。
+
+## 3. 设计说明
+1. 误差估计采用滑窗 one-step WMA 回放，估算 `mape/rmse`。
+2. 可信度优先使用 `validation_mape`，否则回退到估算 `mape`：
+   - `<=0.12 => high`
+   - `<=0.25 => medium`
+   - `>0.25 => low`
+3. 历史点不足时返回 `confidence.level=unknown` 并说明原因。
+
+## 4. 验收标准
+1. forecast 接口向后兼容且新增字段可见。
+2. 前端展示历史/预测时可看到 `mape/rmse/confidence`。
+3. explain 请求包含 `extra_context.forecast_context`。
+
+## 5. 回滚
+1. 后端可忽略新增字段，不影响旧前端解析。
+2. 前端可回退为仅展示 points，不展示置信度。

--- a/src/frontend/src/App.jsx
+++ b/src/frontend/src/App.jsx
@@ -1160,44 +1160,7 @@ export function App() {
       setFaultSpread(spreadResult);
       setTaskImpact(impactResult);
       setAnalysisOverview(overviewResult);
-      const aiSeq = aiExplainSeqRef.current + 1;
-      aiExplainSeqRef.current = aiSeq;
-      setAnalysisAiLoading(true);
-      monitorClientRef.current.analyzeExplain({
-        analysis: overviewResult,
-        scope_type: scopeType,
-        scope_id: scopeId,
-        extra_context: {
-          direct_reason: directReasonFromMetrics || '',
-          scope_observation: scopeObservation || {},
-          security_correlation: overviewResult?.security_correlation || {},
-          impacted_nodes: spreadResult?.impacted_nodes || [],
-          impacted_links: spreadResult?.impacted_links || [],
-          tasks_top: Array.isArray(impactResult?.tasks) ? impactResult.tasks.slice(0, 8) : []
-        }
-      }).then((explainResp) => {
-        if (aiExplainSeqRef.current !== aiSeq) {
-          return;
-        }
-        setAnalysisAiReport(String(explainResp?.report || '').trim());
-        setAnalysisAiMeta({
-          source: explainResp?.source || 'unknown',
-          model: explainResp?.model || '',
-          fallbackReason: explainResp?.fallback_reason || ''
-        });
-      }).catch((explainErr) => {
-        if (aiExplainSeqRef.current !== aiSeq) {
-          return;
-        }
-        setAnalysisAiError(explainErr?.message || 'AI报告生成失败');
-        setAnalysisAiMeta(null);
-        setAnalysisAiReport('');
-      }).finally(() => {
-        if (aiExplainSeqRef.current !== aiSeq) {
-          return;
-        }
-        setAnalysisAiLoading(false);
-      });
+      let forecastContext = {};
       if (scopeType === 'node' || scopeType === 'link') {
         try {
           const eventType = scopeType === 'link' ? 'link_metric' : 'node_metric';
@@ -1229,16 +1192,69 @@ export function App() {
               }))
               .filter((p) => Number.isFinite(p.v))
             : [];
+          forecastContext = {
+            model_type: forecastResp?.model_type || '',
+            model_version: forecastResp?.model_version || '',
+            metrics: forecastResp?.metrics || {},
+            confidence: forecastResp?.confidence || {},
+            horizon: forecastResp?.horizon,
+            window: forecastResp?.window,
+            points: points.slice(0, 24)
+          };
           setSeriesSnapshot({
             eventType,
             metric,
             entityId: scopeId,
-            points
+            points,
+            modelType: forecastResp?.model_type || '',
+            modelVersion: forecastResp?.model_version || '',
+            metrics: forecastResp?.metrics || {},
+            confidence: forecastResp?.confidence || {}
           });
         } catch {
           setSeriesSnapshot(null);
+          forecastContext = {};
         }
       }
+      const aiSeq = aiExplainSeqRef.current + 1;
+      aiExplainSeqRef.current = aiSeq;
+      setAnalysisAiLoading(true);
+      monitorClientRef.current.analyzeExplain({
+        analysis: overviewResult,
+        scope_type: scopeType,
+        scope_id: scopeId,
+        extra_context: {
+          direct_reason: directReasonFromMetrics || '',
+          scope_observation: scopeObservation || {},
+          forecast_context: forecastContext,
+          security_correlation: overviewResult?.security_correlation || {},
+          impacted_nodes: spreadResult?.impacted_nodes || [],
+          impacted_links: spreadResult?.impacted_links || [],
+          tasks_top: Array.isArray(impactResult?.tasks) ? impactResult.tasks.slice(0, 8) : []
+        }
+      }).then((explainResp) => {
+        if (aiExplainSeqRef.current !== aiSeq) {
+          return;
+        }
+        setAnalysisAiReport(String(explainResp?.report || '').trim());
+        setAnalysisAiMeta({
+          source: explainResp?.source || 'unknown',
+          model: explainResp?.model || '',
+          fallbackReason: explainResp?.fallback_reason || ''
+        });
+      }).catch((explainErr) => {
+        if (aiExplainSeqRef.current !== aiSeq) {
+          return;
+        }
+        setAnalysisAiError(explainErr?.message || 'AI报告生成失败');
+        setAnalysisAiMeta(null);
+        setAnalysisAiReport('');
+      }).finally(() => {
+        if (aiExplainSeqRef.current !== aiSeq) {
+          return;
+        }
+        setAnalysisAiLoading(false);
+      });
       const impactedNodeCount = Array.isArray(spreadResult?.impacted_nodes) ? spreadResult.impacted_nodes.length : 0;
       const impactedLinkCount = Array.isArray(spreadResult?.impacted_links) ? spreadResult.impacted_links.length : 0;
       setMonitorActionStatus(`已刷新高级分析结果（高亮节点 ${impactedNodeCount}，链路 ${impactedLinkCount}）`);
@@ -2731,6 +2747,9 @@ export function App() {
                         <div><strong>LSTM预测</strong>: {seriesSnapshot.eventType}/{seriesSnapshot.metric}</div>
                         <div>entity: {seriesSnapshot.entityId || '-'}</div>
                         <div>points: {seriesSnapshot.points?.length || 0}</div>
+                        <div>model: {seriesSnapshot.modelType || '-'}@{seriesSnapshot.modelVersion || '-'}</div>
+                        <div>mape/rmse: {Number.isFinite(Number(seriesSnapshot?.metrics?.mape)) ? Number(seriesSnapshot.metrics.mape).toFixed(4) : '-'} / {Number.isFinite(Number(seriesSnapshot?.metrics?.rmse)) ? Number(seriesSnapshot.metrics.rmse).toFixed(4) : '-'}</div>
+                        <div>confidence: {seriesSnapshot?.confidence?.level || '-'}</div>
                         <div>
                           trend: {(() => {
                             const pts = seriesSnapshot.points || [];


### PR DESCRIPTION
## 背景与目标
实现 I-040：增强预测解释能力，让 AI 报告不仅基于阈值，还可引用预测误差与可信度。

## 变更内容
1. `forecast/lstm` 增加 `metrics.mape`、`metrics.rmse`、`confidence.level`。
2. 新增误差估计函数与置信度分级函数。
3. 前端运行分析流程改为先获取预测，再调用 explain，透传 `forecast_context`。
4. 前端报告展示模型版本、mape/rmse、confidence。
5. 新增 I-040 中文实施设计文档。

## 验证方式与结果
1. `python3 -m py_compile src/collector/app/main.py src/collector/app/contract.py` 通过。
2. `GET /api/v1/bff/forecast/lstm` 实测返回 `metrics` 与 `confidence` 字段。
3. 前端构建通过并可展示新增预测解释信息。

## 风险与回滚方案
1. 风险：误差估计在低样本场景稳定性不足。
2. 缓解：历史点不足时返回 `unknown`，不强行给高置信度。
3. 回滚：前端可忽略新增字段，后端保留向后兼容响应。

## 影响范围
- 后端：forecast 与 explain prompt 输入
- 前端：高级分析展示与 explain 请求上下文
