### PR TITLE
[I-041] 影响域路由语义化升级

### DIFF
--- a/src/collector/app/main.py
+++ b/src/collector/app/main.py
@@ -890,6 +890,11 @@ def create_app() -> FastAPI:
                     "impacted_links": (result.get("impact_graph") or {}).get("impacted_links", []),
                     "boundary_nodes": (result.get("impact_graph") or {}).get("boundary_nodes", []),
                     "policy": (result.get("impact_graph") or {}).get("policy"),
+                    "route_mode": (
+                        "route_first"
+                        if str((result.get("impact_graph") or {}).get("policy") or "") == "route_terminal_paths"
+                        else "topology_fallback"
+                    ),
                     "matched_flows": (result.get("impact_graph") or {}).get("matched_flows"),
                 },
                 "tasks": (result.get("task_impacts") or {}).get("tasks", []),
@@ -899,6 +904,26 @@ def create_app() -> FastAPI:
                     "task_total": len(((result.get("task_impacts") or {}).get("tasks") or [])),
                 },
             }
+            snapshot_payload = app.state.snapshot_store.snapshot(topology_epoch=payload.get("topology_epoch"))
+            monitor = snapshot_payload.get("monitor", {}) if isinstance(snapshot_payload, dict) else {}
+            all_link_ids = sorted(
+                {
+                    _normalize_link_scope(str(x.get("link_uid") or x.get("link_id") or ""))
+                    for x in (monitor.get("links", {}) or {}).values()
+                    if isinstance(x, dict)
+                }
+            )
+            impacted_link_ids = [
+                _normalize_link_scope(str(x))
+                for x in (out.get("topology_impact", {}).get("impacted_links") or [])
+                if str(x).strip()
+            ]
+            impacted_set = set(impacted_link_ids)
+            out["topology_impact"]["filtered_out"] = [x for x in all_link_ids if x and x not in impacted_set][:80]
+            out["topology_impact"]["rank_top"] = _build_route_rank_top(
+                tasks=out.get("tasks") if isinstance(out.get("tasks"), list) else [],
+                impacted_links=impacted_link_ids,
+            )
             out["clusters"] = _build_fault_clusters(
                 seeds=out.get("topology_impact", {}),
                 impact_graph=result.get("impact_graph") if isinstance(result.get("impact_graph"), dict) else {},
@@ -916,7 +941,6 @@ def create_app() -> FastAPI:
                 detected_alarms=result.get("detected_alarms") if isinstance(result.get("detected_alarms"), list) else [],
                 topology_impact=out.get("topology_impact", {}),
             )
-            snapshot_payload = app.state.snapshot_store.snapshot(topology_epoch=payload.get("topology_epoch"))
             out["security_correlation"] = _build_security_correlation(
                 resolved=out.get("resolved", {}),
                 detected_alarms=result.get("detected_alarms") if isinstance(result.get("detected_alarms"), list) else [],
@@ -2379,6 +2403,27 @@ def _build_security_correlation(
         "evidence": evidence,
         "suspected_path": suspected_path,
     }
+
+
+def _build_route_rank_top(*, tasks: list[dict[str, Any]], impacted_links: list[str]) -> list[dict[str, Any]]:
+    scores: dict[str, float] = {}
+    impacted_set = {str(x) for x in impacted_links if str(x).strip()}
+    for t in tasks:
+        if not isinstance(t, dict):
+            continue
+        task_score = float(t.get("priority_score") or 0.0)
+        status = str(t.get("status") or "")
+        bonus = 15.0 if status == "disconnected" else 8.0 if status in {"degraded", "latency_anomaly"} else 0.0
+        links = [str(x) for x in (t.get("impacted_links") or []) if str(x).strip()]
+        for lk in links:
+            lk_norm = _normalize_link_scope(lk)
+            if impacted_set and lk_norm not in impacted_set:
+                continue
+            scores[lk_norm] = max(scores.get(lk_norm, 0.0), task_score + bonus)
+    if not scores:
+        return [{"link_id": x, "score": 0.0, "reason": "route_impact"} for x in impacted_links[:12]]
+    ranked = sorted(scores.items(), key=lambda x: (-x[1], x[0]))[:12]
+    return [{"link_id": k, "score": round(v, 2), "reason": "task_priority"} for k, v in ranked]
 
 
 def _parse_any_timestamp(ts: Any) -> float | None:

--- a/src/collector/docs/I-041_实施设计.md
+++ b/src/collector/docs/I-041_实施设计.md
@@ -1,0 +1,17 @@
+# I-041 实施设计：影响域路由语义化升级
+
+## 目标
+在 `analysis/run` 输出中补充路由语义字段，支持前端明确区分“路由优先”与“拓扑兜底”路径，并给出候选链路过滤与排序依据。
+
+## 输出新增
+- `topology_impact.route_mode`：`route_first|topology_fallback`
+- `topology_impact.filtered_out[]`：本次未纳入影响域的候选链路样本
+- `topology_impact.rank_top[]`：按任务优先级和状态加权后的受影响链路 TopN
+
+## 规则
+1. `policy=route_terminal_paths` 时 `route_mode=route_first`，其余为 `topology_fallback`。
+2. `rank_top` 以任务 `priority_score` 为主，`disconnected/degraded` 状态加权。
+3. `filtered_out` 用于可解释展示，不参与风险评分。
+
+## 回滚
+- 若出现兼容问题，可仅保留已有 `topology_impact` 字段，忽略新增字段。

--- a/src/frontend/src/App.jsx
+++ b/src/frontend/src/App.jsx
@@ -2803,6 +2803,9 @@ export function App() {
                         <div><strong>Topology Impact</strong></div>
                         <div>seeds: {faultSpread.seed_nodes?.length ?? 0}, impacted_nodes: {faultSpread.impacted_nodes?.length ?? 0}</div>
                         <div>impacted_links: {faultSpread.impacted_links?.length ?? 0}, boundary: {faultSpread.boundary_nodes?.length ?? 0}</div>
+                        <div>route_mode: {taskImpact?.topology_impact?.route_mode || '-'}, policy: {taskImpact?.topology_impact?.policy || '-'}</div>
+                        <div>rank_top: {Array.isArray(taskImpact?.topology_impact?.rank_top) ? taskImpact.topology_impact.rank_top.slice(0, 3).map((x) => `${x.link_id}(${Number(x.score || 0).toFixed(1)})`).join(' | ') : '-'}</div>
+                        <div>filtered_out: {Array.isArray(taskImpact?.topology_impact?.filtered_out) ? taskImpact.topology_impact.filtered_out.length : 0}</div>
                       </div>
                     ) : null}
                     {directReasonText ? (


### PR DESCRIPTION
## 背景与目标
实现 I-041 首版交付：将影响域结果从“仅拓扑输出”升级为“路由语义可解释输出”，减少前端侧黑箱感。

## 变更内容
1. `analysis/run` 的 `topology_impact` 新增：
   - `route_mode`（`route_first|topology_fallback`）
   - `filtered_out[]`（本次未纳入影响域的候选链路样本）
   - `rank_top[]`（按任务优先级加权后的受影响链路 TopN）
2. 前端高级分析报告新增上述字段展示。
3. 新增 I-041 中文实施设计文档。

## 验证方式与结果
1. `python3 -m py_compile src/collector/app/main.py` 通过。
2. 经前端容器链路实测：`/monitor-api/api/v1/bff/analysis/run` 返回新增字段。
3. 前端构建通过，报告面板可看到 `route_mode/rank_top/filtered_out`。

## 风险与回滚
1. 风险：`filtered_out` 体量偏大。
2. 缓解：当前已限长采样输出（最多 80）。
3. 回滚：前端可忽略新增字段，后端保持兼容。

## 影响范围
- 后端：analysis.run 输出结构
- 前端：高级分析信息展示
