### PR TITLE
[I-042] 推演复盘报告自动生成

### DIFF
--- a/src/collector/app/main.py
+++ b/src/collector/app/main.py
@@ -1061,13 +1061,60 @@ def create_app() -> FastAPI:
         session = app.state.simulations.get(simulation_id)
         if session is None:
             raise HTTPException(status_code=404, detail=f"simulation not found: {simulation_id}")
+        timeline_rows = session.timeline
+        key_events = _extract_simulation_key_events(timeline_rows)
         return {
             "status": "ok",
             "simulation_id": session.simulation_id,
             "scenario_type": session.scenario_type,
             "current_step": session.current_step,
             "steps_total": session.steps_total,
-            "timeline": session.timeline,
+            "timeline": timeline_rows,
+            "key_events": key_events,
+            "summary": _simulation_timeline_summary(timeline_rows),
+        }
+
+    @app.post("/api/v1/bff/simulation/{simulation_id}/report")
+    async def simulation_report(simulation_id: str, payload: dict[str, object] | None = None) -> dict[str, object]:
+        session = app.state.simulations.get(simulation_id)
+        if session is None:
+            raise HTTPException(status_code=404, detail=f"simulation not found: {simulation_id}")
+        payload = payload or {}
+        provider = str(payload.get("provider") or os.getenv("AI_PROVIDER") or "newapi").strip().lower()
+        if provider not in {"newapi", "gemini", "ollama"}:
+            provider = "newapi"
+        model = str(
+            payload.get("model")
+            or (os.getenv("OLLAMA_MODEL") if provider == "ollama" else os.getenv("AI_MODEL_NAME") or os.getenv("GEMINI_MODEL"))
+            or ("qwen3-coder:latest" if provider == "ollama" else "qwen3-coder:latest")
+        ).strip() or ("qwen3-coder:latest" if provider == "ollama" else "qwen3-coder:latest")
+
+        summary = _simulation_timeline_summary(session.timeline)
+        key_events = _extract_simulation_key_events(session.timeline)
+        prompt = _build_simulation_report_prompt(
+            simulation_id=session.simulation_id,
+            scenario_type=session.scenario_type,
+            focus_scope=session.params,
+            timeline_summary=summary,
+            key_events=key_events,
+            timeline_tail=session.timeline[-8:],
+        )
+        if provider == "ollama":
+            text, used_url, err, used_model = _ollama_generate(prompt=prompt, model=model)
+        else:
+            text, used_url, err, used_model = _newapi_generate(prompt=prompt, model=model)
+        if not text:
+            raise HTTPException(status_code=504, detail=_analysis_error("AI_UNAVAILABLE", err or f"{provider} unavailable"))
+        return {
+            "status": "ok",
+            "simulation_id": session.simulation_id,
+            "scenario_type": session.scenario_type,
+            "model": used_model,
+            "source": provider,
+            "base_url": used_url,
+            "summary": summary,
+            "key_events": key_events,
+            "report_markdown": text,
         }
 
     @app.post("/api/v1/ops/failed-events/replay")
@@ -2472,6 +2519,89 @@ def _forecast_confidence_level(*, validation_mape: float | None, est_mape: float
     if m <= 0.25:
         return "medium"
     return "low"
+
+
+def _simulation_timeline_summary(timeline: list[dict[str, Any]]) -> dict[str, Any]:
+    if not timeline:
+        return {
+            "steps": 0,
+            "risk_peak": "normal",
+            "max_impacted_nodes": 0,
+            "max_impacted_links": 0,
+            "max_alarm_total": 0,
+        }
+    risk_peak = "normal"
+    max_nodes = 0
+    max_links = 0
+    max_alarm = 0
+    for item in timeline:
+        if not isinstance(item, dict):
+            continue
+        risk = str(((item.get("summary") or {}).get("risk_level")) or "normal")
+        if _severity_rank(risk) > _severity_rank(risk_peak):
+            risk_peak = risk
+        max_nodes = max(max_nodes, int(item.get("impacted_nodes") or 0))
+        max_links = max(max_links, int(item.get("impacted_links") or 0))
+        max_alarm = max(max_alarm, int(item.get("detected_alarm_total") or 0))
+    return {
+        "steps": len(timeline),
+        "risk_peak": risk_peak,
+        "max_impacted_nodes": max_nodes,
+        "max_impacted_links": max_links,
+        "max_alarm_total": max_alarm,
+    }
+
+
+def _extract_simulation_key_events(timeline: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for item in timeline:
+        if not isinstance(item, dict):
+            continue
+        step = int(item.get("step") or 0)
+        risk = str(((item.get("summary") or {}).get("risk_level")) or "normal")
+        delta = item.get("delta") if isinstance(item.get("delta"), dict) else {}
+        d_nodes = int(delta.get("impacted_nodes") or 0)
+        d_links = int(delta.get("impacted_links") or 0)
+        d_alarms = int(delta.get("detected_alarm_total") or 0)
+        if risk == "critical" or d_nodes > 8 or d_links > 20 or d_alarms > 5:
+            out.append(
+                {
+                    "step": step,
+                    "risk_level": risk,
+                    "delta": {"impacted_nodes": d_nodes, "impacted_links": d_links, "detected_alarm_total": d_alarms},
+                    "direct_reason": str(item.get("direct_reason") or ""),
+                    "next_action": str(item.get("next_action") or ""),
+                }
+            )
+    return out[:12]
+
+
+def _build_simulation_report_prompt(
+    *,
+    simulation_id: str,
+    scenario_type: str,
+    focus_scope: dict[str, Any],
+    timeline_summary: dict[str, Any],
+    key_events: list[dict[str, Any]],
+    timeline_tail: list[dict[str, Any]],
+) -> str:
+    compact = {
+        "simulation_id": simulation_id,
+        "scenario_type": scenario_type,
+        "focus_scope": focus_scope,
+        "timeline_summary": timeline_summary,
+        "key_events": key_events,
+        "timeline_tail": timeline_tail,
+    }
+    return (
+        "你是网络故障演练复盘专家，请输出一份 Markdown 复盘报告。\n"
+        "要求：\n"
+        "1) 包含“场景摘要、关键拐点、处置动作评估、改进建议、后续演练建议”五个章节；\n"
+        "2) 必须引用输入中的 step 与指标变化，不要编造；\n"
+        "3) 关键拐点至少列出 3 条；\n"
+        "4) 输出中文，简洁但信息完整。\n"
+        f"\n输入：\n{json.dumps(compact, ensure_ascii=False)}\n"
+    )
 
 
 def _safe_float(v: Any) -> float:

--- a/src/collector/docs/I-042_实施设计.md
+++ b/src/collector/docs/I-042_实施设计.md
@@ -1,0 +1,26 @@
+# I-042 实施设计：推演复盘报告自动生成
+
+## 目标
+基于 simulation timeline 自动生成结构化复盘，并通过 AI 输出可读 Markdown 报告，减少人工整理成本。
+
+## 接口
+1. 增强 `GET /api/v1/bff/simulation/{id}/timeline`
+   - 新增 `key_events[]`
+   - 新增 `summary`
+2. 新增 `POST /api/v1/bff/simulation/{id}/report`
+   - 输出 `report_markdown`
+   - 输出 `summary/key_events/model/source`
+
+## 报告内容
+- 场景摘要
+- 关键拐点
+- 处置动作评估
+- 改进建议
+- 后续演练建议
+
+## 前端改动
+- 推演页新增“生成复盘报告”按钮
+- 生成后展示 markdown 正文与关键摘要
+
+## 回滚
+- 若 AI 服务异常，可保留 timeline 展示，不影响原推演流程。

--- a/src/frontend/src/App.jsx
+++ b/src/frontend/src/App.jsx
@@ -463,6 +463,8 @@ export function App() {
   const [analysisSupported, setAnalysisSupported] = useState(true);
   const [simulationLoading, setSimulationLoading] = useState(false);
   const [simulationResult, setSimulationResult] = useState(null);
+  const [simulationReport, setSimulationReport] = useState(null);
+  const [simulationReportLoading, setSimulationReportLoading] = useState(false);
   const [analysisSummary, setAnalysisSummary] = useState(null);
   const [analysisDirectReason, setAnalysisDirectReason] = useState('');
   const [analysisAiReport, setAnalysisAiReport] = useState('');
@@ -1365,6 +1367,7 @@ export function App() {
         first,
         timeline: Array.isArray(timeline) ? timeline.slice(-5) : []
       });
+      setSimulationReport(null);
       const msg = `推演完成：${simulationId}，timeline=${Array.isArray(timeline) ? timeline.length : 0}`;
       setMonitorActionStatus(msg);
       pushToast(msg, 'ok');
@@ -1374,6 +1377,34 @@ export function App() {
       pushToast(msg, 'warn');
     } finally {
       setSimulationLoading(false);
+    }
+  }
+
+  async function generateSimulationReport() {
+    if (!monitorClientRef.current || !simulationResult?.simulationId) {
+      const msg = '请先运行推演再生成复盘报告';
+      setMonitorActionStatus(msg);
+      pushToast(msg, 'warn');
+      return;
+    }
+    try {
+      setSimulationReportLoading(true);
+      const resp = await monitorClientRef.current.createSimulationReport(simulationResult.simulationId, {});
+      setSimulationReport({
+        simulationId: resp?.simulation_id || simulationResult.simulationId,
+        model: resp?.model || '',
+        source: resp?.source || '',
+        summary: resp?.summary || {},
+        keyEvents: Array.isArray(resp?.key_events) ? resp.key_events : [],
+        markdown: String(resp?.report_markdown || '').trim()
+      });
+      pushToast('复盘报告已生成', 'ok');
+    } catch (err) {
+      const msg = err?.message || '生成复盘报告失败';
+      setMonitorActionStatus(msg);
+      pushToast(msg, 'warn');
+    } finally {
+      setSimulationReportLoading(false);
     }
   }
 
@@ -2853,6 +2884,7 @@ export function App() {
                 <span>推演</span>
                 <div className="monitor-header-actions">
                   <button type="button" onClick={runSimulationFlow} disabled={simulationLoading}>{simulationLoading ? '推演中...' : '运行推演'}</button>
+                  <button type="button" onClick={generateSimulationReport} disabled={simulationReportLoading || !simulationResult?.simulationId}>{simulationReportLoading ? '报告生成中...' : '生成复盘报告'}</button>
                 </div>
               </div>
               {simulationResult ? (
@@ -2874,6 +2906,15 @@ export function App() {
                   ) : null}
                 </div>
               ) : <div className="fault-empty">尚未运行推演</div>}
+              {simulationReport ? (
+                <div className="analysis-block">
+                  <div><strong>复盘报告</strong>{simulationReport.model ? ` (${simulationReport.model})` : ''}</div>
+                  <div>simulation: {simulationReport.simulationId}</div>
+                  <div>risk_peak: {simulationReport.summary?.risk_peak || '-'}, max_nodes: {simulationReport.summary?.max_impacted_nodes ?? '-'}, max_links: {simulationReport.summary?.max_impacted_links ?? '-'}</div>
+                  <div>key_events: {simulationReport.keyEvents?.length ?? 0}</div>
+                  <div className="analysis-ai-report">{simulationReport.markdown || '暂无复盘正文'}</div>
+                </div>
+              ) : null}
             </div>
           ) : null}
         </div>

--- a/src/frontend/src/monitor/client.js
+++ b/src/frontend/src/monitor/client.js
@@ -108,7 +108,14 @@ export class MonitorApiClient {
       data = {};
     }
     if (!res.ok || data.status === 'error') {
-      throw new MonitorApiError(data.error_message || data.message || `HTTP ${res.status}`, {
+      const detail = data?.detail;
+      const detailMsg = typeof detail === 'string'
+        ? detail
+        : (detail && typeof detail === 'object'
+          ? (detail.message || detail.error || detail.reason || '')
+          : '');
+      const msg = data.error_message || data.message || detailMsg || `HTTP ${res.status}`;
+      throw new MonitorApiError(msg, {
         code: data.error_code || data.code || MONITOR_ERROR_CODE.INVALID_PAYLOAD,
         status: res.status,
         payload: data
@@ -390,6 +397,16 @@ export class MonitorApiClient {
     }
   }
 
+  async analyzeExplain(payload, options = {}) {
+    const { data } = await this._request('/api/v1/bff/analysis/explain', {
+      method: 'POST',
+      json: true,
+      body: JSON.stringify(payload || {}),
+      token: options.token
+    });
+    return data;
+  }
+
   async analyzeGlobalImpact(payload, options = {}) {
     const { data } = await this._request('/api/v1/bff/analysis/global-impact', {
       method: 'POST',
@@ -423,6 +440,16 @@ export class MonitorApiClient {
   async getSimulationTimeline(simulationId, options = {}) {
     const { data } = await this._request(`/api/v1/bff/simulation/${encodeURIComponent(simulationId)}/timeline`, {
       method: 'GET',
+      token: options.token
+    });
+    return data;
+  }
+
+  async createSimulationReport(simulationId, payload = {}, options = {}) {
+    const { data } = await this._request(`/api/v1/bff/simulation/${encodeURIComponent(simulationId)}/report`, {
+      method: 'POST',
+      json: true,
+      body: JSON.stringify(payload || {}),
       token: options.token
     });
     return data;


### PR DESCRIPTION
## 背景与目标
实现 I-042：将推演 timeline 升级为可自动复盘，新增 AI 复盘报告接口与前端一键生成能力。

## 变更内容
1. 增强 `GET /api/v1/bff/simulation/{id}/timeline`：新增 `summary` 与 `key_events`。
2. 新增 `POST /api/v1/bff/simulation/{id}/report`：输出 `report_markdown`、`summary`、`key_events`、模型信息。
3. 前端推演面板新增“生成复盘报告”按钮与报告展示区。
4. 新增 I-042 中文实施设计文档。

## 验证方式与结果
1. `python3 -m py_compile src/collector/app/main.py` 通过。
2. 端到端验证（frontend proxy 路径）：`create -> step -> step -> report` 返回 `status=ok`。
3. 前端构建通过，推演页可展示 AI 复盘报告。

## 风险与回滚
1. 风险：AI 生成耗时偏高。
2. 缓解：保留 timeline 原始展示，报告按钮按需触发。
3. 回滚：关闭 report 接口调用，不影响原推演流程。

## 影响范围
- 后端：simulation API
- 前端：simulation 页面交互
