### PR TITLE
[I-044] 分析追问式AI交互

### DIFF
--- a/src/collector/app/main.py
+++ b/src/collector/app/main.py
@@ -1045,6 +1045,55 @@ def create_app() -> FastAPI:
             detail=_analysis_error("AI_UNAVAILABLE", err or f"{provider} unavailable"),
         )
 
+    @app.post("/api/v1/bff/analysis/copilot")
+    async def bff_analysis_copilot(payload: dict[str, object]) -> dict[str, object]:
+        analysis = payload.get("analysis")
+        question = str(payload.get("question") or "").strip()
+        if not isinstance(analysis, dict):
+            raise HTTPException(status_code=422, detail="analysis(object) 为必填")
+        if not question:
+            raise HTTPException(status_code=422, detail="question(string) 为必填")
+        session_id = str(payload.get("session_id") or f"copilot-{int(time.time() * 1000)}")
+        history = payload.get("history") if isinstance(payload.get("history"), list) else []
+        provider = str(payload.get("provider") or os.getenv("AI_PROVIDER") or "newapi").strip().lower()
+        if provider not in {"newapi", "gemini", "ollama"}:
+            provider = "newapi"
+        model = str(
+            payload.get("model")
+            or (os.getenv("OLLAMA_MODEL") if provider == "ollama" else os.getenv("AI_MODEL_NAME") or os.getenv("GEMINI_MODEL"))
+            or "qwen3-coder:latest"
+        ).strip() or "qwen3-coder:latest"
+        prompt = _build_copilot_prompt(analysis=analysis, question=question, history=history)
+        if provider == "ollama":
+            text, _, err, used_model = _ollama_generate(prompt=prompt, model=model)
+        else:
+            text, _, err, used_model = _newapi_generate(prompt=prompt, model=model)
+        if not text:
+            answer = _copilot_rule_fallback(analysis=analysis, question=question)
+            refs = _copilot_references(analysis=analysis)
+            return {
+                "status": "ok",
+                "session_id": session_id,
+                "answer": answer,
+                "references": refs,
+                "confidence": "low",
+                "fallback": True,
+                "fallback_reason": err or f"{provider} unavailable",
+                "source": "rule_fallback",
+                "model": used_model or model,
+            }
+        refs = _copilot_references(analysis=analysis)
+        return {
+            "status": "ok",
+            "session_id": session_id,
+            "answer": text.strip(),
+            "references": refs,
+            "confidence": "medium",
+            "fallback": False,
+            "source": provider,
+            "model": used_model,
+        }
+
     @app.post("/api/v1/bff/simulation/create")
     async def simulation_create(payload: dict[str, object]) -> dict[str, object]:
         scenario_type = str(payload.get("scenario_type", "link_down")).strip().lower()
@@ -2779,6 +2828,54 @@ def _build_mapping_suggestion_prompt(
         "3) 给出3条人工确认动作；\n"
         "4) 不要输出JSON。\n"
         f"\n输入：\n{json.dumps(compact, ensure_ascii=False)}"
+    )
+
+
+def _build_copilot_prompt(*, analysis: dict[str, Any], question: str, history: list[Any]) -> str:
+    compact = {
+        "resolved": analysis.get("resolved"),
+        "summary": analysis.get("summary"),
+        "topology_impact": analysis.get("topology_impact"),
+        "reasoning": analysis.get("reasoning"),
+        "narrative": analysis.get("narrative"),
+        "security_correlation": analysis.get("security_correlation"),
+        "tasks_top": (analysis.get("tasks") or [])[:8] if isinstance(analysis.get("tasks"), list) else [],
+        "history": history[-6:] if isinstance(history, list) else [],
+        "question": question,
+    }
+    return (
+        "你是网络故障分析副驾。请基于输入上下文回答用户追问。\n"
+        "要求：\n"
+        "1) 先给结论，再给依据；\n"
+        "2) 至少引用2条证据（指标/阈值/影响对象/任务状态）；\n"
+        "3) 若数据不足，明确指出缺失项；\n"
+        "4) 输出中文纯文本，不要JSON。\n"
+        f"\n上下文：\n{json.dumps(compact, ensure_ascii=False)}"
+    )
+
+
+def _copilot_references(*, analysis: dict[str, Any]) -> list[dict[str, Any]]:
+    summary = analysis.get("summary") if isinstance(analysis.get("summary"), dict) else {}
+    topo = analysis.get("topology_impact") if isinstance(analysis.get("topology_impact"), dict) else {}
+    refs: list[dict[str, Any]] = [
+        {"type": "summary", "key": "risk_level", "value": str(summary.get("risk_level") or "-")},
+        {"type": "summary", "key": "detected_alarm_total", "value": int(summary.get("detected_alarm_total") or 0)},
+        {"type": "impact", "key": "impacted_nodes", "value": len(topo.get("impacted_nodes") or [])},
+        {"type": "impact", "key": "impacted_links", "value": len(topo.get("impacted_links") or [])},
+    ]
+    return refs
+
+
+def _copilot_rule_fallback(*, analysis: dict[str, Any], question: str) -> str:
+    summary = analysis.get("summary") if isinstance(analysis.get("summary"), dict) else {}
+    topo = analysis.get("topology_impact") if isinstance(analysis.get("topology_impact"), dict) else {}
+    risk = str(summary.get("risk_level") or "unknown")
+    n = len(topo.get("impacted_nodes") or [])
+    l = len(topo.get("impacted_links") or [])
+    return (
+        f"当前无法调用AI服务，先给规则化答复。你问的是：{question}\n"
+        f"基于当前分析，风险等级为 {risk}，影响节点 {n} 个、影响链路 {l} 条。\n"
+        "建议先查看直接原因与阈值证据，再按高优先级任务链路逐项排查。"
     )
 
 

--- a/src/collector/docs/I-044_实施设计.md
+++ b/src/collector/docs/I-044_实施设计.md
@@ -1,0 +1,26 @@
+# I-044 实施设计：分析追问式AI交互
+
+## 目标
+在“单次AI报告”基础上增加多轮追问能力，支持运维围绕当前分析对象持续提问，并保留会话上下文。
+
+## 新增接口
+- `POST /api/v1/bff/analysis/copilot`
+
+### 请求
+- `analysis`：当前 analysis.run 结果
+- `session_id`：会话ID（可选）
+- `question`：追问文本
+- `history[]`：历史问答（可选）
+
+### 响应
+- `answer`：回答正文
+- `references[]`：证据引用
+- `confidence`：置信度
+- `fallback`：是否规则回退
+
+## 前端改动
+- 分析报告区新增“追问式分析”输入框
+- 展示最近多轮问答历史与引用证据
+
+## 回滚
+- 关闭 copilot 区域，不影响现有分析与AI报告。

--- a/src/frontend/src/App.jsx
+++ b/src/frontend/src/App.jsx
@@ -471,6 +471,10 @@ export function App() {
   const [analysisAiMeta, setAnalysisAiMeta] = useState(null);
   const [analysisAiLoading, setAnalysisAiLoading] = useState(false);
   const [analysisAiError, setAnalysisAiError] = useState('');
+  const [copilotQuestion, setCopilotQuestion] = useState('');
+  const [copilotHistory, setCopilotHistory] = useState([]);
+  const [copilotSessionId, setCopilotSessionId] = useState('');
+  const [copilotLoading, setCopilotLoading] = useState(false);
   const [replayMode, setReplayMode] = useState(false);
   const [showLayerPanel, setShowLayerPanel] = useState(false);
   const [showFaultPanel, setShowFaultPanel] = useState(false);
@@ -939,6 +943,9 @@ export function App() {
       setAnalysisAiReport('');
       setAnalysisAiMeta(null);
       setAnalysisAiError('');
+      setCopilotHistory([]);
+      setCopilotQuestion('');
+      setCopilotSessionId('');
       setFaultSpread(null);
       setTaskImpact(null);
       let analysisMode = 'auto';
@@ -1272,6 +1279,38 @@ export function App() {
       pushToast(msg, 'warn');
     } finally {
       setAnalysisLoading(false);
+    }
+  }
+
+  async function askCopilot() {
+    const q = String(copilotQuestion || '').trim();
+    if (!q || !taskImpact || !monitorClientRef.current) {
+      return;
+    }
+    try {
+      setCopilotLoading(true);
+      const resp = await monitorClientRef.current.analysisCopilot({
+        analysis: taskImpact,
+        session_id: copilotSessionId || undefined,
+        question: q,
+        history: copilotHistory.map((x) => ({ q: x.q, a: x.a }))
+      });
+      const sid = String(resp?.session_id || copilotSessionId || '');
+      if (sid) setCopilotSessionId(sid);
+      const row = {
+        q,
+        a: String(resp?.answer || '').trim(),
+        refs: Array.isArray(resp?.references) ? resp.references : [],
+        confidence: resp?.confidence || '-',
+        fallback: Boolean(resp?.fallback)
+      };
+      setCopilotHistory((prev) => [...prev, row].slice(-8));
+      setCopilotQuestion('');
+    } catch (err) {
+      const msg = err?.message || '追问失败';
+      pushToast(msg, 'warn');
+    } finally {
+      setCopilotLoading(false);
     }
   }
 
@@ -2872,6 +2911,27 @@ export function App() {
                       {analysisAiError ? <div className="analysis-error">{analysisAiError}</div> : null}
                       {analysisAiMeta?.source === 'fallback' ? <div>当前使用规则兜底报告：{analysisAiMeta?.fallbackReason || 'ollama unavailable'}</div> : null}
                       {analysisAiReport ? <div className="analysis-ai-report">{analysisAiReport}</div> : (!analysisAiLoading ? <div className="fault-empty">暂无AI报告</div> : null)}
+                    </div>
+                    <div className="analysis-block">
+                      <div><strong>追问式分析</strong>{copilotSessionId ? ` (${copilotSessionId})` : ''}</div>
+                      <div style={{ display: 'flex', gap: 6 }}>
+                        <input
+                          value={copilotQuestion}
+                          onChange={(e) => setCopilotQuestion(e.target.value)}
+                          placeholder="继续追问，例如：先恢复哪条链路？"
+                          style={{ flex: 1, minWidth: 0 }}
+                        />
+                        <button type="button" onClick={askCopilot} disabled={copilotLoading || !copilotQuestion.trim()}>{copilotLoading ? '回答中...' : '发送'}</button>
+                      </div>
+                      {copilotHistory.length === 0 ? <div className="fault-empty">暂无追问记录</div> : null}
+                      {copilotHistory.map((x, idx) => (
+                        <div key={`cp-${idx}`} className="analysis-ai-report">
+                          <div><strong>Q{idx + 1}</strong>: {x.q}</div>
+                          <div><strong>A{idx + 1}</strong>: {x.a || '-'}</div>
+                          <div>confidence: {x.confidence}{x.fallback ? ' (fallback)' : ''}</div>
+                          <div>refs: {Array.isArray(x.refs) ? x.refs.map((r) => `${r.type}.${r.key}=${r.value}`).join(' | ') : '-'}</div>
+                        </div>
+                      ))}
                     </div>
                   </aside>
                 ) : null}

--- a/src/frontend/src/monitor/client.js
+++ b/src/frontend/src/monitor/client.js
@@ -407,6 +407,16 @@ export class MonitorApiClient {
     return data;
   }
 
+  async analysisCopilot(payload, options = {}) {
+    const { data } = await this._request('/api/v1/bff/analysis/copilot', {
+      method: 'POST',
+      json: true,
+      body: JSON.stringify(payload || {}),
+      token: options.token
+    });
+    return data;
+  }
+
   async analyzeGlobalImpact(payload, options = {}) {
     const { data } = await this._request('/api/v1/bff/analysis/global-impact', {
       method: 'POST',


### PR DESCRIPTION
## 背景与目标
实现 I-044：在单次分析报告基础上增加多轮追问能力，支持围绕当前分析对象进行会话式问答。

## 变更内容
1. 新增后端接口 `POST /api/v1/bff/analysis/copilot`。
2. 支持请求字段：`analysis/session_id/question/history`。
3. 响应字段：`answer/references/confidence`，并支持 AI 不可用时规则回退。
4. 前端报告区新增“追问式分析”输入框与问答历史展示。
5. 新增 I-044 中文实施设计文档。

## 验证方式与结果
1. `python3 -m py_compile src/collector/app/main.py` 通过。
2. 端到端联调：`/api/v1/bff/analysis/copilot` 返回 `status=ok`，包含 `session_id/answer/references/confidence`。
3. 前端构建通过，追问交互可用。

## 风险与回滚
1. 风险：AI 追问回答出现幻觉。
2. 缓解：提示词约束 + references 固定返回。
3. 回滚：隐藏前端追问区，保留 explain 单次报告。

## 影响范围
- 后端：analysis copilot API
- 前端：分析报告交互
