### PR TITLE
[I-045] 分析统一输出层（规则判级 + 证据包 + AI报告）

### DIFF
--- a/src/collector/app/main.py
+++ b/src/collector/app/main.py
@@ -992,6 +992,37 @@ def create_app() -> FastAPI:
                 detected_alarms=result.get("detected_alarms") if isinstance(result.get("detected_alarms"), list) else [],
                 topology_impact=out.get("topology_impact", {}),
             )
+            findings = [
+                x for x in ((out.get("reasoning") or {}).get("top_findings") or [])
+                if isinstance(x, dict)
+            ][:10]
+            primary_finding = findings[0] if findings else {}
+            primary_evidence = [
+                str(x) for x in (primary_finding.get("evidence") or [])
+                if str(x).strip()
+            ]
+            out["risk_result"] = {
+                "source": "rules_lstm",
+                "risk_level": (out.get("summary") or {}).get("risk_level"),
+                "max_alarm_severity": (out.get("summary") or {}).get("max_alarm_severity"),
+                "focused_scope_severity": (out.get("summary") or {}).get("focused_scope_severity"),
+                "detected_alarm_total": (out.get("summary") or {}).get("detected_alarm_total"),
+                "direct_reason": "、".join(primary_evidence[:3]) if primary_evidence else None,
+                "primary_finding": primary_finding or None,
+            }
+            out["evidence_bundle"] = {
+                "scope_observation": payload.get("scope_observation") if isinstance(payload.get("scope_observation"), dict) else {},
+                "top_findings": findings,
+                "detected_alarms": [
+                    x for x in (result.get("detected_alarms") or [])
+                    if isinstance(x, dict)
+                ][:30],
+                "impacted_nodes_count": len(out.get("topology_impact", {}).get("impacted_nodes") or []),
+                "impacted_links_count": len(out.get("topology_impact", {}).get("impacted_links") or []),
+                "impacted_nodes_sample": (out.get("topology_impact", {}).get("impacted_nodes") or [])[:20],
+                "impacted_links_sample": (out.get("topology_impact", {}).get("impacted_links") or [])[:20],
+                "tasks_top": (out.get("tasks") or [])[:10],
+            }
             out["security_correlation"] = _build_security_correlation(
                 resolved=out.get("resolved", {}),
                 detected_alarms=result.get("detected_alarms") if isinstance(result.get("detected_alarms"), list) else [],
@@ -1000,6 +1031,7 @@ def create_app() -> FastAPI:
                 monitor_payload=snapshot_payload,
                 window_sec=max(60, min(int(payload.get("window_sec", 300)), 3600)),
             )
+            out["evidence_bundle"]["security_correlation"] = out.get("security_correlation") or {}
             ok = True
             return out
         finally:
@@ -1412,6 +1444,8 @@ def _build_ollama_analysis_prompt(
     topo = analysis.get("topology_impact") if isinstance(analysis.get("topology_impact"), dict) else {}
     reasoning = analysis.get("reasoning") if isinstance(analysis.get("reasoning"), dict) else {}
     narrative = analysis.get("narrative") if isinstance(analysis.get("narrative"), dict) else {}
+    risk_result = analysis.get("risk_result") if isinstance(analysis.get("risk_result"), dict) else {}
+    evidence_bundle = analysis.get("evidence_bundle") if isinstance(analysis.get("evidence_bundle"), dict) else {}
     tasks = analysis.get("tasks") if isinstance(analysis.get("tasks"), list) else []
     extra_obj = extra_context if isinstance(extra_context, dict) else {}
     obs = extra_obj.get("scope_observation") if isinstance(extra_obj.get("scope_observation"), dict) else {}
@@ -1423,6 +1457,7 @@ def _build_ollama_analysis_prompt(
         "scope_type": scope_type,
         "scope_id": scope_id,
         "risk_level": summary.get("risk_level"),
+        "risk_result": risk_result,
         "max_alarm_severity": summary.get("max_alarm_severity"),
         "focused_scope_severity": summary.get("focused_scope_severity"),
         "detected_alarm_total": summary.get("detected_alarm_total"),
@@ -1435,6 +1470,7 @@ def _build_ollama_analysis_prompt(
         "verdict": narrative.get("verdict"),
         "next_action": narrative.get("next_action"),
         "tasks_top10": tasks[:10],
+        "evidence_bundle": evidence_bundle,
         "scope_observation": obs,
         "forecast_context": fc,
         "direct_reason_hint": extra_obj.get("direct_reason"),
@@ -1443,8 +1479,9 @@ def _build_ollama_analysis_prompt(
     data_json = json.dumps(compact, ensure_ascii=False)
     return (
         "你是网络故障管理专家。请基于输入数据写一份“可执行、可验证”的诊断报告。\n"
+        "强约束：risk_result 是规则/LSTM给出的最终判级，AI不得改写、不得降级或升级该风险级别。\n"
         "要求：\n"
-        "1) 先给结论（风险级别+紧急程度）\n"
+        "1) 先给结论（沿用 risk_result 的风险级别+紧急程度）\n"
         "2) 明确“直接原因”：必须写出命中的指标名、观测值、阈值、比较关系（例如 cpu=85.6% >= 82%）\n"
         "3) 给出“证据链”：至少3条，优先使用 scope_observation 与 top_findings，不要泛泛而谈\n"
         "4) 说明影响范围：影响节点数/链路数，并点名最多5个关键对象\n"

--- a/src/frontend/src/App.jsx
+++ b/src/frontend/src/App.jsx
@@ -2356,6 +2356,13 @@ export function App() {
   const autoNodeCandidates = faultCandidates.filter((x) => x.source === 'auto' && x.scopeType === 'node');
   const autoLinkCandidates = faultCandidates.filter((x) => x.source === 'auto' && x.scopeType === 'link');
   const directReasonText = analysisDirectReason;
+  const ruleRiskResult = (taskImpact && typeof taskImpact.risk_result === 'object') ? taskImpact.risk_result : null;
+  const evidenceBundle = (taskImpact && typeof taskImpact.evidence_bundle === 'object') ? taskImpact.evidence_bundle : null;
+  const displayRiskLevel = String(ruleRiskResult?.risk_level || taskImpact?.summary?.risk_level || taskImpact?.risk_level || '-');
+  const displayDirectReason = String(ruleRiskResult?.direct_reason || directReasonText || '').trim();
+  const evidenceFindings = Array.isArray(evidenceBundle?.top_findings) ? evidenceBundle.top_findings : [];
+  const evidenceAlarms = Array.isArray(evidenceBundle?.detected_alarms) ? evidenceBundle.detected_alarms : [];
+  const evidenceTasks = Array.isArray(evidenceBundle?.tasks_top) ? evidenceBundle.tasks_top : [];
   const reportHistoryPoints = (() => {
     if (!analysisSummary?.scopeType || !analysisSummary?.scopeId) {
       return [];
@@ -2868,45 +2875,29 @@ export function App() {
                         <span className="legend-swatch forecast"></span>LSTM预测
                       </div>
                     </div>
-                    {faultSpread ? (
-                      <div className="analysis-block">
-                        <div><strong>Topology Impact</strong></div>
-                        <div>seeds: {faultSpread.seed_nodes?.length ?? 0}, impacted_nodes: {faultSpread.impacted_nodes?.length ?? 0}</div>
-                        <div>impacted_links: {faultSpread.impacted_links?.length ?? 0}, boundary: {faultSpread.boundary_nodes?.length ?? 0}</div>
-                        <div>route_mode: {taskImpact?.topology_impact?.route_mode || '-'}, policy: {taskImpact?.topology_impact?.policy || '-'}</div>
-                        <div>rank_top: {Array.isArray(taskImpact?.topology_impact?.rank_top) ? taskImpact.topology_impact.rank_top.slice(0, 3).map((x) => `${x.link_id}(${Number(x.score || 0).toFixed(1)})`).join(' | ') : '-'}</div>
-                        <div>filtered_out: {Array.isArray(taskImpact?.topology_impact?.filtered_out) ? taskImpact.topology_impact.filtered_out.length : 0}</div>
-                      </div>
-                    ) : null}
-                    {directReasonText ? (
-                      <div className="analysis-block">
-                        <div><strong>直接原因</strong></div>
-                        <div>{directReasonText}</div>
-                      </div>
-                    ) : null}
-                    {taskImpact?.reasoning ? (
-                      <div className="analysis-block">
-                        <div><strong>判定依据</strong>: {taskImpact.reasoning.fault_domain || '-'}</div>
-                        <div>{taskImpact.reasoning.note || '-'}</div>
-                      </div>
-                    ) : null}
-                    {taskImpact?.security_correlation ? (
-                      <div className="analysis-block">
-                        <div><strong>安全联动</strong>: {taskImpact.security_correlation.level || 'none'} (score={Number(taskImpact.security_correlation.score || 0).toFixed(2)})</div>
-                        <div>security_events: {taskImpact.security_correlation.matched_security_events ?? 0}, window: {taskImpact.security_correlation.window_sec ?? '-'}s</div>
-                        <div>evidence: {Array.isArray(taskImpact.security_correlation.evidence) ? taskImpact.security_correlation.evidence.map((e) => `${e.type}:${e.detail}`).slice(0, 2).join(' | ') : '-'}</div>
-                      </div>
-                    ) : null}
-                    {taskImpact?.narrative ? (
-                      <div className="analysis-block">
-                        <div><strong>人类可读结论</strong>: {taskImpact.narrative.verdict || '-'}</div>
-                        <div>{taskImpact.narrative.summary_sentence || '-'}</div>
-                      </div>
-                    ) : null}
+                    <div className="analysis-block">
+                      <div><strong>风险预警（规则/LSTM）</strong></div>
+                      <div>risk: {displayRiskLevel}</div>
+                      <div>source: {ruleRiskResult?.source || 'rules_lstm'}</div>
+                      <div>max_severity: {ruleRiskResult?.max_alarm_severity || taskImpact?.summary?.max_alarm_severity || '-'}</div>
+                      <div>focused_severity: {ruleRiskResult?.focused_scope_severity || taskImpact?.summary?.focused_scope_severity || '-'}</div>
+                      <div>detected_alarms: {ruleRiskResult?.detected_alarm_total ?? taskImpact?.summary?.detected_alarm_total ?? '-'}</div>
+                      {displayDirectReason ? <div>直接原因: {displayDirectReason}</div> : null}
+                    </div>
+                    <div className="analysis-block">
+                      <div><strong>证据摘要</strong></div>
+                      <div>impacted_nodes: {evidenceBundle?.impacted_nodes_count ?? (faultSpread?.impacted_nodes?.length ?? 0)}</div>
+                      <div>impacted_links: {evidenceBundle?.impacted_links_count ?? (faultSpread?.impacted_links?.length ?? 0)}</div>
+                      <div>top_findings: {evidenceFindings.length}</div>
+                      <div>detected_alarms: {evidenceAlarms.length}</div>
+                      <div>tasks_top: {evidenceTasks.length}</div>
+                      <div>route_mode: {taskImpact?.topology_impact?.route_mode || '-'}, policy: {taskImpact?.topology_impact?.policy || '-'}</div>
+                      <div>security_level: {evidenceBundle?.security_correlation?.level || taskImpact?.security_correlation?.level || 'none'}</div>
+                    </div>
                     <div className="analysis-block">
                       <div><strong>AI详细报告</strong>{analysisAiMeta?.model ? ` (${analysisAiMeta.model})` : ''}</div>
-                      <div>固定信息: risk={taskImpact?.summary?.risk_level || taskImpact?.risk_level || '-'}, impacted_nodes={faultSpread?.impacted_nodes?.length ?? 0}, impacted_links={faultSpread?.impacted_links?.length ?? 0}</div>
-                      {directReasonText ? <div>固定原因: {directReasonText}</div> : null}
+                      <div>固定信息: risk={displayRiskLevel}, impacted_nodes={evidenceBundle?.impacted_nodes_count ?? (faultSpread?.impacted_nodes?.length ?? 0)}, impacted_links={evidenceBundle?.impacted_links_count ?? (faultSpread?.impacted_links?.length ?? 0)}</div>
+                      {displayDirectReason ? <div>固定原因: {displayDirectReason}</div> : null}
                       {analysisAiLoading ? <div>生成中...</div> : null}
                       {analysisAiError ? <div className="analysis-error">{analysisAiError}</div> : null}
                       {analysisAiMeta?.source === 'fallback' ? <div>当前使用规则兜底报告：{analysisAiMeta?.fallbackReason || 'ollama unavailable'}</div> : null}


### PR DESCRIPTION
## 背景
根据 `spec.md` 与当前联调反馈，分析链路需要明确分层：
- 风险判级必须来自规则/LSTM（稳定、可审计）
- AI 负责可读解释与处置建议（增强可理解性）
- 前端展示避免混杂过多旧字段，统一到固定三层

关联 Issue: #35

## 本次改动
### 1) 后端统一输出层（collector）
文件：`src/collector/app/main.py`
- 在 `POST /api/v1/bff/analysis/run` 输出新增 `risk_result`：
  - `source`（固定 `rules_lstm`）
  - `risk_level`
  - `max_alarm_severity`
  - `focused_scope_severity`
  - `detected_alarm_total`
  - `direct_reason`
  - `primary_finding`
- 在同接口新增 `evidence_bundle`：
  - `scope_observation`
  - `top_findings`
  - `detected_alarms`
  - `impacted_nodes_count/impacted_links_count`
  - `impacted_nodes_sample/impacted_links_sample`
  - `tasks_top`
  - `security_correlation`

### 2) AI 报告约束（explain prompt）
文件：`src/collector/app/main.py`
- `_build_ollama_analysis_prompt` 增加强约束：
  - `risk_result` 为规则/LSTM最终判级，AI 不得改写风险等级
- prompt 中显式注入 `risk_result` + `evidence_bundle`，让 AI 基于更完整原始证据生成报告

### 3) 前端报告三层化
文件：`src/frontend/src/App.jsx`
- 高级分析报告区改为固定三层：
  - `风险预警（规则/LSTM）`
  - `证据摘要`
  - `AI详细报告`
- AI 报告固定信息改为优先读取 `risk_result` 与 `evidence_bundle`
- 移除部分旧的分散判定块，减少用户理解成本

## 验证
- 前端构建：`npm run build`（通过）
- 后端语法：`python3 -m py_compile src/collector/app/main.py`（通过）
- 容器重构并重启：
  - `net_analysis_collector`（9010）
  - `topo-frontend-bff`（8080）
- 健康检查：
  - `GET /health` 返回 `status=ok`
  - `GET /api/v1/ops/slo` 返回 `status=ok`
  - 前端首页 `http://127.0.0.1:8080` 返回 `200`

## 风险与兼容性
- 兼容旧字段：`summary/topology_impact/tasks` 仍保留
- 新前端优先读取新分层字段，若后端旧版本可降级使用旧字段（已保底）

## 后续建议
- 在 `analysis_contract_v1.md` 补充 `risk_result/evidence_bundle` 字段契约（可在后续 issue 单独提交）
