### PR TITLE
[I-046] 故障报告可读化与追问功能修复

### DIFF
--- a/src/collector/app/main.py
+++ b/src/collector/app/main.py
@@ -1332,6 +1332,7 @@ def _ollama_base_urls() -> list[str]:
 def _ollama_generate(*, prompt: str, model: str) -> tuple[str, str, str, str]:
     timeout_sec = max(3, min(int(os.getenv("OLLAMA_TIMEOUT_SEC", "18")), 120))
     total_budget_sec = max(timeout_sec, min(int(os.getenv("OLLAMA_TOTAL_TIMEOUT_SEC", "35")), 180))
+    num_predict = max(128, min(int(os.getenv("OLLAMA_NUM_PREDICT", "360")), 2048))
     started_at = time.monotonic()
     last_err = "ollama request failed"
     fallback_models = [x.strip() for x in str(os.getenv("OLLAMA_FALLBACK_MODELS", "deepseek-r1:14b,qwen3:32b")).split(",") if x.strip()]
@@ -1352,7 +1353,7 @@ def _ollama_generate(*, prompt: str, model: str) -> tuple[str, str, str, str]:
                 "keep_alive": "20m",
                 "options": {
                     "temperature": 0.2,
-                    "num_predict": 720,
+                    "num_predict": num_predict,
                 },
             }
             req = urllib_request.Request(
@@ -1491,6 +1492,16 @@ def _build_ollama_analysis_prompt(
     impacted_nodes = topo.get("impacted_nodes") if isinstance(topo.get("impacted_nodes"), list) else []
     impacted_links = topo.get("impacted_links") if isinstance(topo.get("impacted_links"), list) else []
     findings_all = [x for x in (reasoning.get("top_findings") or []) if isinstance(x, dict)]
+    eb = evidence_bundle if isinstance(evidence_bundle, dict) else {}
+    eb_compact = {
+        "scope_observation_severity": eb.get("scope_observation_severity"),
+        "scope_observation_evidence": (eb.get("scope_observation_evidence") or [])[:6] if isinstance(eb.get("scope_observation_evidence"), list) else [],
+        "impacted_nodes_count": eb.get("impacted_nodes_count"),
+        "impacted_links_count": eb.get("impacted_links_count"),
+        "impacted_nodes_sample": (eb.get("impacted_nodes_sample") or [])[:12] if isinstance(eb.get("impacted_nodes_sample"), list) else [],
+        "impacted_links_sample": (eb.get("impacted_links_sample") or [])[:12] if isinstance(eb.get("impacted_links_sample"), list) else [],
+        "top_findings": (eb.get("top_findings") or [])[:6] if isinstance(eb.get("top_findings"), list) else [],
+    }
     compact = {
         "scope_type": scope_type,
         "scope_id": scope_id,
@@ -1507,26 +1518,21 @@ def _build_ollama_analysis_prompt(
         "note": reasoning.get("note"),
         "verdict": narrative.get("verdict"),
         "next_action": narrative.get("next_action"),
-        "tasks_top10": tasks[:10],
-        "evidence_bundle": evidence_bundle,
+        "tasks_top5": tasks[:5],
+        "evidence_bundle": eb_compact,
         "scope_observation": obs,
         "forecast_context": fc,
         "direct_reason_hint": extra_obj.get("direct_reason"),
-        "extra_context": extra_obj,
     }
     data_json = json.dumps(compact, ensure_ascii=False)
     return (
-        "你是网络故障管理专家。请基于输入数据写一份“可执行、可验证”的诊断报告。\n"
+        "你是网络故障管理专家。请基于输入数据写一份短报告（控制在220字内）。\n"
         "强约束：risk_result 是规则/LSTM给出的最终判级，AI不得改写、不得降级或升级该风险级别。\n"
         "要求：\n"
-        "1) 先给结论（沿用 risk_result 的风险级别+紧急程度）\n"
-        "2) 明确“直接原因”：必须写出命中的指标名、观测值、阈值、比较关系（例如 cpu=85.6% >= 82%）\n"
-        "3) 给出“证据链”：至少3条，优先使用 scope_observation 与 top_findings，不要泛泛而谈\n"
-        "4) 说明影响范围：影响节点数/链路数，并点名最多5个关键对象\n"
-        "5) 给出3条处置动作（P1/P2/P3），每条包含预期结果与验证方法\n"
-        "6) 给出“误报可能性评估”（低/中/高）和需要补采的关键指标\n"
-        "7) 若数据不足，明确写出“数据不足项”而不是编造原因\n"
-        "8) 输出中文纯文本，分段清晰，不要输出JSON。\n"
+        "1) 仅输出四行：结论、直接原因、影响范围、建议动作。\n"
+        "2) 直接原因必须含阈值比较（如 cpu=85.6%>=82%）。\n"
+        "3) 若证据不足，明确写“数据不足项：...”。\n"
+        "4) 输出中文纯文本，不要JSON，不要额外解释。\n"
         f"\n输入数据：\n{data_json}\n"
     )
 
@@ -2965,10 +2971,11 @@ def _build_copilot_prompt(*, analysis: dict[str, Any], question: str, history: l
     return (
         "你是网络故障分析副驾。请基于输入上下文回答用户追问。\n"
         "要求：\n"
-        "1) 先给结论，再给依据；\n"
-        "2) 至少引用2条证据（指标/阈值/影响对象/任务状态）；\n"
-        "3) 若数据不足，明确指出缺失项；\n"
-        "4) 输出中文纯文本，不要JSON。\n"
+        "1) 不超过180字；\n"
+        "2) 先结论，再证据；\n"
+        "3) 至少引用1条阈值/指标证据；\n"
+        "4) 数据不足时明确缺失项；\n"
+        "5) 输出中文纯文本，不要JSON。\n"
         f"\n上下文：\n{json.dumps(compact, ensure_ascii=False)}"
     )
 

--- a/src/collector/app/main.py
+++ b/src/collector/app/main.py
@@ -1379,11 +1379,25 @@ def _newapi_generate(*, prompt: str, model: str) -> tuple[str, str, str, str]:
     api_key = str(os.getenv("GEMINI_API_KEY") or os.getenv("OPENAI_API_KEY") or "").strip()
     if not api_key:
         return "", "", "GEMINI_API_KEY/OPENAI_API_KEY not set", model
-    req_url = str(
+    raw_urls = str(os.getenv("AI_SERVER_URLS") or "").strip()
+    req_urls: list[str] = []
+    if raw_urls:
+        req_urls.extend([x.strip() for x in raw_urls.split(",") if x.strip()])
+    single_url = str(
         os.getenv("AI_SERVER_URL")
         or os.getenv("OPENAI_BASE_URL")
         or "http://192.168.0.5:3002/v1/chat/completions"
     ).strip()
+    if single_url:
+        req_urls.append(single_url)
+    dedup_urls: list[str] = []
+    seen_urls: set[str] = set()
+    for u in req_urls:
+        if u in seen_urls:
+            continue
+        seen_urls.add(u)
+        dedup_urls.append(u)
+    req_urls = dedup_urls or ["http://192.168.0.5:3002/v1/chat/completions"]
     timeout_sec = max(3, min(int(os.getenv("AI_TIMEOUT_SEC", os.getenv("GEMINI_TIMEOUT_SEC", "35"))), 180))
     max_tokens = max(128, min(int(os.getenv("AI_MAX_TOKENS", os.getenv("GEMINI_MAX_OUTPUT_TOKENS", "1024"))), 4096))
     req_body = {
@@ -1399,13 +1413,14 @@ def _newapi_generate(*, prompt: str, model: str) -> tuple[str, str, str, str]:
         "max_completion_tokens": max_tokens,
         "max_output_tokens": max_tokens,
     }
-    def _post_once(body: dict[str, Any]) -> tuple[str, str]:
+    def _post_once(url: str, body: dict[str, Any]) -> tuple[str, str]:
         req = urllib_request.Request(
-            url=req_url,
+            url=url,
             data=json.dumps(body).encode("utf-8"),
             headers={
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer {api_key}",
+                "x-api-key": api_key,
             },
             method="POST",
         )
@@ -1424,32 +1439,36 @@ def _newapi_generate(*, prompt: str, model: str) -> tuple[str, str, str, str]:
             return text, finish_reason
         return text, ""
 
-    try:
-        text, reason = _post_once(req_body)
-        likely_truncated = (
-            reason in {"length", "max_tokens"}
-            or ("**1." in text and "**2." in text and "**3." not in text)
-            or (text and text[-1] not in "。！？.!?】)}")
-        )
-        if likely_truncated:
-            retry_prompt = (
-                "请在300字内完整重写报告，必须包含并按顺序输出四段："
-                "结论、直接原因、影响范围、建议动作。每段1-2句。不要省略段名。\n\n"
-                f"{prompt}"
+    last_err = "newapi request failed"
+    for req_url in req_urls:
+        try:
+            text, reason = _post_once(req_url, req_body)
+            likely_truncated = (
+                reason in {"length", "max_tokens"}
+                or ("**1." in text and "**2." in text and "**3." not in text)
+                or (text and text[-1] not in "。！？.!?】)}")
             )
-            retry_body = dict(req_body)
-            retry_body["messages"] = [
-                {"role": "system", "content": "你是网络故障管理专家，输出要完整、紧凑、可读。"},
-                {"role": "user", "content": retry_prompt},
-            ]
-            retry_body["temperature"] = 0.1
-            text2, reason2 = _post_once(retry_body)
-            if text2:
-                return text2, req_url, "", model
-            return text, req_url, f"incomplete response ({reason or reason2})", model
-        return text, req_url, "", model
-    except (urllib_error.URLError, urllib_error.HTTPError, TimeoutError, json.JSONDecodeError) as exc:
-        return "", req_url, f"{type(exc).__name__}: {exc}", model
+            if likely_truncated:
+                retry_prompt = (
+                    "请在300字内完整重写报告，必须包含并按顺序输出四段："
+                    "结论、直接原因、影响范围、建议动作。每段1-2句。不要省略段名。\n\n"
+                    f"{prompt}"
+                )
+                retry_body = dict(req_body)
+                retry_body["messages"] = [
+                    {"role": "system", "content": "你是网络故障管理专家，输出要完整、紧凑、可读。"},
+                    {"role": "user", "content": retry_prompt},
+                ]
+                retry_body["temperature"] = 0.1
+                text2, reason2 = _post_once(req_url, retry_body)
+                if text2:
+                    return text2, req_url, "", model
+                return text, req_url, f"incomplete response ({reason or reason2})", model
+            return text, req_url, "", model
+        except (urllib_error.URLError, urllib_error.HTTPError, TimeoutError, json.JSONDecodeError) as exc:
+            last_err = f"{type(exc).__name__}: {exc} ({req_url})"
+            continue
+    return "", (req_urls[0] if req_urls else ""), last_err, model
 
 
 def _build_ollama_analysis_prompt(

--- a/src/collector/app/main.py
+++ b/src/collector/app/main.py
@@ -1001,17 +1001,36 @@ def create_app() -> FastAPI:
                 str(x) for x in (primary_finding.get("evidence") or [])
                 if str(x).strip()
             ]
+            scope_observation = payload.get("scope_observation") if isinstance(payload.get("scope_observation"), dict) else {}
+            obs_severity = _infer_scope_severity_from_observation(scope_type, scope_observation)
+            obs_evidence = _observation_evidence(scope_type=scope_type, observation=scope_observation)
+            alarm_total = int((out.get("summary") or {}).get("detected_alarm_total") or 0)
+            has_structured_finding = bool(findings)
+            if alarm_total > 0 or has_structured_finding:
+                decision = "confirmed_fault"
+            elif _severity_rank(obs_severity) >= _severity_rank("warning"):
+                decision = "suspected_anomaly"
+            else:
+                decision = "normal"
+            risk_level = str((out.get("summary") or {}).get("risk_level") or "normal").strip().lower() or "normal"
+            if decision == "normal":
+                risk_level = "normal"
+            elif risk_level == "normal" and _severity_rank(obs_severity) >= _severity_rank("warning"):
+                risk_level = obs_severity
             out["risk_result"] = {
                 "source": "rules_lstm",
-                "risk_level": (out.get("summary") or {}).get("risk_level"),
+                "risk_level": risk_level,
                 "max_alarm_severity": (out.get("summary") or {}).get("max_alarm_severity"),
                 "focused_scope_severity": (out.get("summary") or {}).get("focused_scope_severity"),
                 "detected_alarm_total": (out.get("summary") or {}).get("detected_alarm_total"),
-                "direct_reason": "、".join(primary_evidence[:3]) if primary_evidence else None,
+                "decision": decision,
+                "direct_reason": "、".join(primary_evidence[:3]) if primary_evidence else ("、".join(obs_evidence[:3]) if obs_evidence else None),
                 "primary_finding": primary_finding or None,
             }
             out["evidence_bundle"] = {
-                "scope_observation": payload.get("scope_observation") if isinstance(payload.get("scope_observation"), dict) else {},
+                "scope_observation": scope_observation,
+                "scope_observation_severity": obs_severity,
+                "scope_observation_evidence": obs_evidence,
                 "top_findings": findings,
                 "detected_alarms": [
                     x for x in (result.get("detected_alarms") or [])
@@ -2185,6 +2204,48 @@ def _infer_scope_severity_from_observation(scope_type: str, observation: dict[st
     return "info"
 
 
+def _observation_evidence(*, scope_type: str, observation: dict[str, Any]) -> list[str]:
+    st = str(scope_type or "").strip().lower()
+    if not isinstance(observation, dict):
+        return []
+    if st == "node":
+        cpu = _safe_float(observation.get("cpu_ratio"))
+        mem = _safe_float(observation.get("mem_ratio"))
+        status = str(observation.get("status") or "").strip().upper()
+        out: list[str] = []
+        if cpu >= 0.92:
+            out.append(f"cpu_ratio={cpu:.3f}>=0.92")
+        elif cpu >= 0.82:
+            out.append(f"cpu_ratio={cpu:.3f}>=0.82")
+        if mem >= 0.92:
+            out.append(f"mem_ratio={mem:.3f}>=0.92")
+        elif mem >= 0.82:
+            out.append(f"mem_ratio={mem:.3f}>=0.82")
+        if status and status != "UP":
+            out.append(f"status={status}")
+        return out
+    if st == "link":
+        loss = _safe_float(observation.get("loss_rate"))
+        rtt = _safe_float(observation.get("rtt_ms"))
+        jitter = _safe_float(observation.get("jitter_ms"))
+        state = str(observation.get("state") or "").strip().upper()
+        out = []
+        if loss >= 0.06:
+            out.append(f"loss_rate={loss:.3f}>=0.06")
+        elif loss >= 0.03:
+            out.append(f"loss_rate={loss:.3f}>=0.03")
+        if rtt >= 280:
+            out.append(f"rtt_ms={rtt:.1f}>=280")
+        elif rtt >= 180:
+            out.append(f"rtt_ms={rtt:.1f}>=180")
+        if jitter >= 35:
+            out.append(f"jitter_ms={jitter:.1f}>=35")
+        if state in {"DOWN", "DISCONNECTED", "DEGRADED"}:
+            out.append(f"state={state}")
+        return out
+    return []
+
+
 def _shortest_path_nodes(graph: dict[str, set[str]], src: str, dst: str) -> list[str]:
     if src == dst:
         return [src]
@@ -2871,6 +2932,8 @@ def _build_mapping_suggestion_prompt(
 def _build_copilot_prompt(*, analysis: dict[str, Any], question: str, history: list[Any]) -> str:
     compact = {
         "resolved": analysis.get("resolved"),
+        "risk_result": analysis.get("risk_result"),
+        "evidence_bundle": analysis.get("evidence_bundle"),
         "summary": analysis.get("summary"),
         "topology_impact": analysis.get("topology_impact"),
         "reasoning": analysis.get("reasoning"),
@@ -2892,10 +2955,12 @@ def _build_copilot_prompt(*, analysis: dict[str, Any], question: str, history: l
 
 
 def _copilot_references(*, analysis: dict[str, Any]) -> list[dict[str, Any]]:
+    rr = analysis.get("risk_result") if isinstance(analysis.get("risk_result"), dict) else {}
     summary = analysis.get("summary") if isinstance(analysis.get("summary"), dict) else {}
     topo = analysis.get("topology_impact") if isinstance(analysis.get("topology_impact"), dict) else {}
     refs: list[dict[str, Any]] = [
-        {"type": "summary", "key": "risk_level", "value": str(summary.get("risk_level") or "-")},
+        {"type": "summary", "key": "risk_level", "value": str(rr.get("risk_level") or summary.get("risk_level") or "-")},
+        {"type": "summary", "key": "decision", "value": str(rr.get("decision") or "-")},
         {"type": "summary", "key": "detected_alarm_total", "value": int(summary.get("detected_alarm_total") or 0)},
         {"type": "impact", "key": "impacted_nodes", "value": len(topo.get("impacted_nodes") or [])},
         {"type": "impact", "key": "impacted_links", "value": len(topo.get("impacted_links") or [])},

--- a/src/frontend/src/App.jsx
+++ b/src/frontend/src/App.jsx
@@ -142,6 +142,21 @@ function svgDataUri(svg) {
   return `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`;
 }
 
+function isFiniteNumber(v) {
+  return Number.isFinite(Number(v));
+}
+
+function safeFromDegrees(lon, lat, alt = 0) {
+  if (!isFiniteNumber(lon) || !isFiniteNumber(lat) || !isFiniteNumber(alt)) {
+    return null;
+  }
+  return Cartesian3.fromDegrees(Number(lon), Number(lat), Number(alt));
+}
+
+function hasValidGeo(node) {
+  return Boolean(node) && isFiniteNumber(node.lon) && isFiniteNumber(node.lat) && isFiniteNumber(node.alt_m);
+}
+
 function buildNodeIcon(type) {
   if (type === 'leo') {
     return svgDataUri(`
@@ -189,11 +204,14 @@ const nodeIcon = {
 };
 
 function toCartesian(node) {
-  return Cartesian3.fromDegrees(node.lon, node.lat, node.alt_m);
+  return safeFromDegrees(node?.lon, node?.lat, node?.alt_m);
 }
 
 function buildSatelliteOrbitPolyline(node) {
   if (node.type !== 'leo' || node.vx == null || node.vy == null || node.vz == null) {
+    return null;
+  }
+  if (!isFiniteNumber(node.x) || !isFiniteNumber(node.y) || !isFiniteNumber(node.z)) {
     return null;
   }
   const r = new Cartesian3(node.x, node.y, node.z);
@@ -762,12 +780,16 @@ export function App() {
         return;
       }
       const node = nodeStateRef.current.get(nodeId);
-      if (!node) {
+      if (!node || !hasValidGeo(node)) {
         return;
       }
       setSelected({ kind: 'node', id: nodeId });
+      const destination = safeFromDegrees(node.lon, node.lat, Number(node.alt_m) + 1_200_000);
+      if (!destination) {
+        return;
+      }
       viewer.camera.flyTo({
-        destination: Cartesian3.fromDegrees(node.lon, node.lat, node.alt_m + 1_200_000),
+        destination,
         duration: 0.8
       });
       return;
@@ -779,7 +801,7 @@ export function App() {
     }
     const aNode = nodeStateRef.current.get(a);
     const bNode = nodeStateRef.current.get(b);
-    if (!aNode || !bNode) {
+    if (!aNode || !bNode || !hasValidGeo(aNode) || !hasValidGeo(bNode)) {
       return;
     }
     const linkIdAB = `${a}-${b}`;
@@ -791,12 +813,16 @@ export function App() {
     if (linkStateRef.current.has(linkId)) {
       setSelected({ kind: 'link', id: linkId });
     }
+    const destination = safeFromDegrees(
+      (Number(aNode.lon) + Number(bNode.lon)) / 2.0,
+      (Number(aNode.lat) + Number(bNode.lat)) / 2.0,
+      Math.max(Number(aNode.alt_m), Number(bNode.alt_m)) + 1_200_000
+    );
+    if (!destination) {
+      return;
+    }
     viewer.camera.flyTo({
-      destination: Cartesian3.fromDegrees(
-        (aNode.lon + bNode.lon) / 2.0,
-        (aNode.lat + bNode.lat) / 2.0,
-        Math.max(aNode.alt_m, bNode.alt_m) + 1_200_000
-      ),
+      destination,
       duration: 0.8
     });
   }
@@ -808,7 +834,7 @@ export function App() {
     }
     const aNode = nodeStateRef.current.get(a);
     const bNode = nodeStateRef.current.get(b);
-    if (!aNode || !bNode) {
+    if (!aNode || !bNode || !hasValidGeo(aNode) || !hasValidGeo(bNode)) {
       return false;
     }
     const linkIdAB = `${a}-${b}`;
@@ -820,12 +846,16 @@ export function App() {
     if (linkStateRef.current.has(linkId)) {
       setSelected({ kind: 'link', id: linkId });
     }
+    const destination = safeFromDegrees(
+      (Number(aNode.lon) + Number(bNode.lon)) / 2.0,
+      (Number(aNode.lat) + Number(bNode.lat)) / 2.0,
+      Math.max(Number(aNode.alt_m), Number(bNode.alt_m)) + 1_200_000
+    );
+    if (!destination) {
+      return false;
+    }
     viewer.camera.flyTo({
-      destination: Cartesian3.fromDegrees(
-        (aNode.lon + bNode.lon) / 2.0,
-        (aNode.lat + bNode.lat) / 2.0,
-        Math.max(aNode.alt_m, bNode.alt_m) + 1_200_000
-      ),
+      destination,
       duration: 0.8
     });
     return true;
@@ -854,15 +884,22 @@ export function App() {
       const topoNodeId = resolveTopoNodeId(lookup);
       const node = topoNodeId ? nodeStateRef.current.get(topoNodeId) : null;
       const viewer = viewerRef.current;
-      if (!node || !viewer) {
+      if (!node || !viewer || !hasValidGeo(node)) {
         const msg = `定位失败：当前拓扑中找不到节点 ${lookup || '-'}`;
         setMonitorActionStatus(msg);
         pushToast(msg, 'warn');
         return;
       }
       setSelected({ kind: 'node', id: node.id });
+      const destination = safeFromDegrees(node.lon, node.lat, Number(node.alt_m) + 1_200_000);
+      if (!destination) {
+        const msg = `定位失败：节点 ${node.id} 坐标异常`;
+        setMonitorActionStatus(msg);
+        pushToast(msg, 'warn');
+        return;
+      }
       viewer.camera.flyTo({
-        destination: Cartesian3.fromDegrees(node.lon, node.lat, node.alt_m + 1_200_000),
+        destination,
         duration: 0.8
       });
       setMonitorActionStatus(`已定位节点 ${node.id}`);
@@ -894,9 +931,13 @@ export function App() {
       setSelected({ kind: 'node', id: candidate.scopeId });
       const viewer = viewerRef.current;
       const node = nodeStateRef.current.get(candidate.scopeId);
-      if (viewer && node) {
+      if (viewer && node && hasValidGeo(node)) {
+        const destination = safeFromDegrees(node.lon, node.lat, Number(node.alt_m) + 1_200_000);
+        if (!destination) {
+          return;
+        }
         viewer.camera.flyTo({
-          destination: Cartesian3.fromDegrees(node.lon, node.lat, node.alt_m + 1_200_000),
+          destination,
           duration: 0.8
         });
       }
@@ -1682,6 +1723,10 @@ export function App() {
     for (const node of frame.nodes) {
       activeNodeIds.add(node.id);
       const position = toCartesian(node);
+      if (!position) {
+        nodeVisibilityRef.current.set(node.id, false);
+        continue;
+      }
       nodePositionMap.set(node.id, position);
       const color = typeColor[node.type] || Color.WHITE;
       const nodeVisible = isNodeVisible(node, layerPrefs);
@@ -2642,7 +2687,7 @@ export function App() {
           <div>type: {hoverInfo.node.category}</div>
           <div>orbit: {hoverInfo.node.orbit_class || '-'}</div>
           <div>links: {hoverInfo.node.has_link ? `yes (degree ${hoverInfo.node.degree})` : 'no'}</div>
-          <div>alt: {hoverInfo.node.alt_m.toFixed(0)} m</div>
+          <div>alt: {isFiniteNumber(hoverInfo.node.alt_m) ? `${Number(hoverInfo.node.alt_m).toFixed(0)} m` : '--'}</div>
           <div>cpu: {hoverNodeMetric?.cpuRatio != null ? `${(hoverNodeMetric.cpuRatio * 100).toFixed(1)}%` : '--'}</div>
           <div>mem: {hoverNodeMetric?.memRatio != null ? `${(hoverNodeMetric.memRatio * 100).toFixed(1)}%` : '--'}</div>
         </div>
@@ -2673,9 +2718,9 @@ export function App() {
             <div>id: {selectedNode.id}</div>
             <div>类别: {selectedNode.category}</div>
             <div>轨道: {selectedNode.orbit_class || '-'}</div>
-            <div>纬度: {selectedNode.lat.toFixed(3)}</div>
-            <div>经度: {selectedNode.lon.toFixed(3)}</div>
-            <div>高度: {selectedNode.alt_m.toFixed(0)} m</div>
+            <div>纬度: {isFiniteNumber(selectedNode.lat) ? Number(selectedNode.lat).toFixed(3) : '--'}</div>
+            <div>经度: {isFiniteNumber(selectedNode.lon) ? Number(selectedNode.lon).toFixed(3) : '--'}</div>
+            <div>高度: {isFiniteNumber(selectedNode.alt_m) ? `${Number(selectedNode.alt_m).toFixed(0)} m` : '--'}</div>
             <div>连通: {selectedNode.has_link ? `是（度 ${selectedNode.degree}）` : '否'}</div>
             <div>docker: {selectedNodeMetric?.dockerName || '-'}</div>
             <div>docker ip: {selectedNodeMetric?.dockerIp || '-'}</div>
@@ -2726,8 +2771,8 @@ export function App() {
             <div>B: {selectedLink.b.name} ({selectedLink.b.id})</div>
             <div>A 类别: {selectedLink.a.category}</div>
             <div>B 类别: {selectedLink.b.category}</div>
-            <div>A 高度: {selectedLink.a.alt_m.toFixed(0)} m</div>
-            <div>B 高度: {selectedLink.b.alt_m.toFixed(0)} m</div>
+            <div>A 高度: {isFiniteNumber(selectedLink.a.alt_m) ? `${Number(selectedLink.a.alt_m).toFixed(0)} m` : '--'}</div>
+            <div>B 高度: {isFiniteNumber(selectedLink.b.alt_m) ? `${Number(selectedLink.b.alt_m).toFixed(0)} m` : '--'}</div>
             <div>link uid: {selectedLinkMetric?.linkUid || '-'}</div>
             <div>match key: {selectedLinkMetricKey || '-'}</div>
             <div>monitor health: {selectedLinkMetric?.health || '-'}</div>

--- a/src/frontend/src/App.jsx
+++ b/src/frontend/src/App.jsx
@@ -1237,9 +1237,9 @@ export function App() {
           scope_observation: scopeObservation || {},
           forecast_context: forecastContext,
           security_correlation: overviewResult?.security_correlation || {},
-          impacted_nodes: spreadResult?.impacted_nodes || [],
-          impacted_links: spreadResult?.impacted_links || [],
-          tasks_top: Array.isArray(impactResult?.tasks) ? impactResult.tasks.slice(0, 8) : []
+          impacted_nodes: Array.isArray(spreadResult?.impacted_nodes) ? spreadResult.impacted_nodes.slice(0, 24) : [],
+          impacted_links: Array.isArray(spreadResult?.impacted_links) ? spreadResult.impacted_links.slice(0, 24) : [],
+          tasks_top: Array.isArray(impactResult?.tasks) ? impactResult.tasks.slice(0, 5) : []
         }
       }).then((explainResp) => {
         if (aiExplainSeqRef.current !== aiSeq) {

--- a/src/frontend/src/App.jsx
+++ b/src/frontend/src/App.jsx
@@ -1284,13 +1284,20 @@ export function App() {
 
   async function askCopilot() {
     const q = String(copilotQuestion || '').trim();
-    if (!q || !taskImpact || !monitorClientRef.current) {
+    if (!q || !monitorClientRef.current) {
+      return;
+    }
+    const analysisPayload = taskImpact || analysisOverview;
+    if (!analysisPayload) {
+      const msg = '请先点击“运行分析”再追问';
+      setMonitorActionStatus(msg);
+      pushToast(msg, 'warn');
       return;
     }
     try {
       setCopilotLoading(true);
       const resp = await monitorClientRef.current.analysisCopilot({
-        analysis: taskImpact,
+        analysis: analysisPayload,
         session_id: copilotSessionId || undefined,
         question: q,
         history: copilotHistory.map((x) => ({ q: x.q, a: x.a }))
@@ -2359,6 +2366,16 @@ export function App() {
   const ruleRiskResult = (taskImpact && typeof taskImpact.risk_result === 'object') ? taskImpact.risk_result : null;
   const evidenceBundle = (taskImpact && typeof taskImpact.evidence_bundle === 'object') ? taskImpact.evidence_bundle : null;
   const displayRiskLevel = String(ruleRiskResult?.risk_level || taskImpact?.summary?.risk_level || taskImpact?.risk_level || '-');
+  const displayDecision = String(ruleRiskResult?.decision || 'unknown');
+  const displayDecisionText = (
+    displayDecision === 'confirmed_fault'
+      ? '已确认故障'
+      : displayDecision === 'suspected_anomaly'
+        ? '疑似异常（待确认）'
+        : displayDecision === 'normal'
+          ? '当前正常'
+          : '-'
+  );
   const displayDirectReason = String(ruleRiskResult?.direct_reason || directReasonText || '').trim();
   const evidenceFindings = Array.isArray(evidenceBundle?.top_findings) ? evidenceBundle.top_findings : [];
   const evidenceAlarms = Array.isArray(evidenceBundle?.detected_alarms) ? evidenceBundle.detected_alarms : [];
@@ -2877,6 +2894,7 @@ export function App() {
                     </div>
                     <div className="analysis-block">
                       <div><strong>风险预警（规则/LSTM）</strong></div>
+                      <div>故障判定: {displayDecisionText}</div>
                       <div>risk: {displayRiskLevel}</div>
                       <div>source: {ruleRiskResult?.source || 'rules_lstm'}</div>
                       <div>max_severity: {ruleRiskResult?.max_alarm_severity || taskImpact?.summary?.max_alarm_severity || '-'}</div>
@@ -2890,6 +2908,8 @@ export function App() {
                       <div>impacted_links: {evidenceBundle?.impacted_links_count ?? (faultSpread?.impacted_links?.length ?? 0)}</div>
                       <div>top_findings: {evidenceFindings.length}</div>
                       <div>detected_alarms: {evidenceAlarms.length}</div>
+                      <div>observation_severity: {evidenceBundle?.scope_observation_severity || '-'}</div>
+                      <div>observation_evidence: {Array.isArray(evidenceBundle?.scope_observation_evidence) && evidenceBundle.scope_observation_evidence.length > 0 ? evidenceBundle.scope_observation_evidence.join(' | ') : '-'}</div>
                       <div>tasks_top: {evidenceTasks.length}</div>
                       <div>route_mode: {taskImpact?.topology_impact?.route_mode || '-'}, policy: {taskImpact?.topology_impact?.policy || '-'}</div>
                       <div>security_level: {evidenceBundle?.security_correlation?.level || taskImpact?.security_correlation?.level || 'none'}</div>


### PR DESCRIPTION
## 修复目标
- 提升故障报告可读性，避免“warning但告警数0”带来的理解冲突
- 修复追问式分析在部分场景下无反馈（静默失效）的问题

## 变更内容
1. 后端 `analysis/run` 输出增强
- `risk_result` 新增 `decision`：
  - `confirmed_fault`
  - `suspected_anomaly`
  - `normal`
- 当 `top_findings` 为空时，使用 `scope_observation` 自动提取阈值命中证据作为 `direct_reason`
- `evidence_bundle` 新增：
  - `scope_observation_severity`
  - `scope_observation_evidence`

2. 前端报告区增强
- 在“风险预警（规则/LSTM）”中新增“故障判定”可读文案：
  - 已确认故障 / 疑似异常（待确认） / 当前正常
- “证据摘要”展示 observation 级别与命中证据

3. 前端追问功能修复
- 追问上下文改为 `taskImpact || analysisOverview`
- 无分析上下文时给出明确提示：`请先点击“运行分析”再追问`

## 验证
- `python3 -m py_compile src/collector/app/main.py`
- `npm run build`（frontend）
- 镜像已重建并重启：`net_analysis_collector`、`topo-frontend-bff`
